### PR TITLE
Fix premature Transaction Succeeded for CoW Swap orders

### DIFF
--- a/src/futarchyJS/futarchy.js
+++ b/src/futarchyJS/futarchy.js
@@ -1202,12 +1202,18 @@ export const createFutarchy = (options = {}) => {
         onSwap?.();
         
         const tx = await executeV3Swap(fromToken, toToken, parsedAmount, signer);
-        
+
         onSwapSent?.(tx);
-        
+
         // Wait for confirmation
-        statusManager.update('Waiting for confirmation...');
-        const receipt = await tx.wait(TRANSACTION_SETTINGS.CONFIRMATION_BLOCKS);
+        let receipt;
+        if (tx.isCowSwapOrder) {
+          statusManager.update('CoW Swap order submitted');
+          receipt = { status: 1, transactionHash: tx.hash };
+        } else {
+          statusManager.update('Waiting for confirmation...');
+          receipt = await tx.wait(TRANSACTION_SETTINGS.CONFIRMATION_BLOCKS);
+        }
         
         // Update balances
         await balanceManager.updateBalances();

--- a/src/hooks/useFutarchy.js
+++ b/src/hooks/useFutarchy.js
@@ -539,11 +539,15 @@ export const useFutarchy = (config = {}) => {
 
         handleStatus(`V3 Router swap transaction submitted: ${tx.hash}`, true);
         if (onSwapComplete) onSwapComplete(tx);
-        
-        handleStatus(`Waiting for router swap confirmation...`, true);
-        swapReceipt = await tx.wait(TRANSACTION_SETTINGS.CONFIRMATION_BLOCKS);
-        
-        handleStatus(`V3 Router swap confirmed! Hash: ${swapReceipt.transactionHash}`, true);
+
+        if (tx.isCowSwapOrder) {
+          handleStatus(`CoW Swap order submitted. Order ID: ${tx.hash}`, true);
+          swapReceipt = { status: 1, transactionHash: tx.hash };
+        } else {
+          handleStatus(`Waiting for router swap confirmation...`, true);
+          swapReceipt = await tx.wait(TRANSACTION_SETTINGS.CONFIRMATION_BLOCKS);
+          handleStatus(`V3 Router swap confirmed! Hash: ${swapReceipt.transactionHash}`, true);
+        }
       } else {
         // Use SushiSwap V2 for the swap (original implementation)
         console.log('Using SushiSwap V2 for swap');

--- a/src/utils/sushiswapV3Helper.js
+++ b/src/utils/sushiswapV3Helper.js
@@ -444,8 +444,17 @@ export const executeV3Swap = async ({ // Keep original signature for CoW path
         const signedOrder = await cowSdk.signOrder(order);
         const orderId = await cowSdk.cowApi.sendOrder({ order: { ...order, ...signedOrder }, owner: await signer.getAddress() });
         // -----
-        console.log('[CoW Swap Debug] Returning mock transaction object for Order ID:', orderId);
-        return { hash: orderId, wait: async () => { await new Promise(resolve => setTimeout(resolve, 100)); return { status: 1, transactionHash: orderId, confirmations: 1 }; }, confirmations: 0 };
+        console.log('[CoW Swap Debug] Returning CoW Swap order object for Order ID:', orderId);
+        return {
+          hash: orderId,
+          isCowSwapOrder: true,
+          wait: async () => {
+            throw new Error(
+              'Cannot call wait() on a CoW Swap order. Use CoW API polling to track order status.'
+            );
+          },
+          confirmations: 0
+        };
       }
     } catch (error) {
       // ... existing CoW Swap error handling (parsing specific API errors) ...
@@ -701,8 +710,17 @@ export const executeRedemptionSwap = async ({ // Keep signature focused on CoW p
       throw sendError;
     }
 
-    console.log('[CoW Swap Debug] Redemption Returning mock transaction object for Order ID:', orderId);
-    return { hash: orderId, wait: async () => { /* mock wait */ }, confirmations: 0 }; // Return mock tx
+    console.log('[CoW Swap Debug] Redemption returning CoW Swap order object for Order ID:', orderId);
+    return {
+      hash: orderId,
+      isCowSwapOrder: true,
+      wait: async () => {
+        throw new Error(
+          'Cannot call wait() on a CoW Swap order. Use CoW API polling to track order status.'
+        );
+      },
+      confirmations: 0
+    };
 
   } catch (error) {
     // ... existing CoW Swap redemption error handling ...


### PR DESCRIPTION
## Summary

Fixes #9. Also related to #13.

- **`sushiswapV3Helper.js`**: Replace mock `wait()` on CoW Swap order results with throwing stubs + `isCowSwapOrder` flag. Both `executeV3Swap` and `executeRedemptionSwap` are fixed.
- **`useFutarchy.js`**: Guard `wait()` call — CoW orders skip waiting and show "CoW Swap order submitted" instead of fake confirmation.
- **`futarchy.js`**: Same guard in the `createFutarchy` V3 swap path.

`ConfirmSwapModal` is unaffected — it already uses CoW API polling for order tracking.

## Test plan

- [ ] Execute a CoW Swap — should show "order submitted" instead of instant fake "confirmed"
- [ ] Execute an Algebra/SushiSwap swap — should work unchanged (real tx objects, not mocks)
- [ ] ConfirmSwapModal CoW flow — should continue working via API polling