### PR TITLE
Add position tab indicator and auto-switch after trade

### DIFF
--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -2902,6 +2902,21 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     native: rawBalances.native   // Native xDAI balance
   }), [rawBalances]);
 
+  // Detect whether the user holds any active conditional-token position
+  const hasActivePosition = useMemo(() => {
+    try {
+      const currDiff = ethers.utils.parseUnits(
+        positions?.currencyYes?.total || '0', 18
+      ).sub(ethers.utils.parseUnits(positions?.currencyNo?.total || '0', 18));
+      const compDiff = ethers.utils.parseUnits(
+        positions?.companyYes?.total || '0', 18
+      ).sub(ethers.utils.parseUnits(positions?.companyNo?.total || '0', 18));
+      return !currDiff.isZero() || !compDiff.isZero();
+    } catch {
+      return false;
+    }
+  }, [positions]);
+
   // Balance manager handles wallet disconnection automatically
 
   const [showEventDetails, setShowEventDetails] = useState(false);
@@ -4553,6 +4568,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
   const handleTransactionComplete = (transactionDetails) => {
     // Refresh balances or any other state that needs updating
     refetchBalances();
+    // Auto-switch to Position tab so the user sees their updated position
+    setActiveTab('position');
   };
 
   // Add selectedAction state
@@ -5282,6 +5299,9 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
                                   }`}
                               >
                                 Position
+                                {hasActivePosition && (
+                                  <span className="inline-block w-1.5 h-1.5 ml-1 rounded-full bg-futarchyGreen9" />
+                                )}
                               </button>
                             </>
                           )}


### PR DESCRIPTION
## Summary
- Show a green dot on the Position tab when the connected wallet holds active conditional-token positions (non-zero YES-NO surplus)
- Auto-switch to the Position tab after a successful swap so users immediately see their updated holdings

## Test plan
- [ ] Connect wallet with no positions → Position tab has no dot
- [ ] Execute a swap → close modal → auto-switches to Position tab, green dot visible
- [ ] Wallet with existing positions → Position tab shows green dot on page load
- [ ] Disconnect wallet → dot disappears

Closes #17