### PR TITLE
Point API URL to api.futarchy.fi

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   NODE_VERSION = "20"
   NPM_FLAGS = "--legacy-peer-deps"
-  NEXT_PUBLIC_API_URL = "https://stag.api.tickspread.com"
+  NEXT_PUBLIC_API_URL = "https://api.futarchy.fi"
   NEXT_PUBLIC_API_VERSION = "v1"
   NEXT_PUBLIC_RPC_URL = "https://rpc.gnosischain.com"
   NEXT_PUBLIC_SUPABASE_URL = "https://nvhqdqtlsdboctqjcelq.supabase.co"


### PR DESCRIPTION
## Summary
- Replaces `stag.api.tickspread.com` with `api.futarchy.fi` for `NEXT_PUBLIC_API_URL` in `netlify.toml`
- Part of migration off the old AWS-hosted backend

## Test plan
- [ ] Netlify build succeeds with new env var baked in
- [ ] Frontend loads (API calls will 404 until backend is stood up on GCP at `api.futarchy.fi`)