### PR TITLE
Remove tickspread.com URL references

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
   NODE_VERSION = "20"
   NPM_FLAGS = "--legacy-peer-deps"
   NEXT_PUBLIC_API_URL = "https://api.futarchy.fi"
+  NEXT_PUBLIC_POOL_API_URL = "https://api.futarchy.fi"
   NEXT_PUBLIC_API_VERSION = "v1"
   NEXT_PUBLIC_RPC_URL = "https://rpc.gnosischain.com"
   NEXT_PUBLIC_SUPABASE_URL = "https://nvhqdqtlsdboctqjcelq.supabase.co"

--- a/src/hooks/useLatestPrices.js
+++ b/src/hooks/useLatestPrices.js
@@ -1,9 +1,5 @@
 import { useState, useEffect } from 'react';
 
-// Pool API endpoints for YES/NO position data (keep these for chart data)
-const YES_POOL_URL = 'https://stag.api.tickspread.com/v4/candles?pool_id=0x9a14d28909f42823Ee29847F87A15Fb3b6E8AEd3&interval=3600000';
-const NO_POOL_URL = 'https://stag.api.tickspread.com/v4/candles?pool_id=0x6E33153115Ab58dab0e0F1E3a2ccda6e67FA5cD7&interval=3600000';
-
 // Base token addresses for Balancer SDK
 const BASE_COMPANY_TOKEN_ADDRESS = "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb"; // GNO
 const BASE_CURRENCY_TOKEN_ADDRESS = "0xaf204776c7245bF4147c2612BF6e5972Ee483701"; // sDAI

--- a/src/hooks/usePoolData.js
+++ b/src/hooks/usePoolData.js
@@ -5,7 +5,7 @@ import { ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS } from '../config/featureFlags';
 // Pool data subgraph endpoints are now dynamic per chain - see getSubgraphEndpoint(chainId)
 
 // API base URL - avoid mixed content (upgrade http->https when page is https)
-const RAW_API_BASE_URL = process.env.NEXT_PUBLIC_POOL_API_URL || 'https://stag.api.tickspread.com';
+const RAW_API_BASE_URL = process.env.NEXT_PUBLIC_POOL_API_URL || 'https://api.futarchy.fi';
 const normalizeBaseUrl = (url) => {
   try {
     if (typeof window !== 'undefined' && window.location?.protocol === 'https:' && url.startsWith('http://')) {


### PR DESCRIPTION
## Summary
- Remove unused `YES_POOL_URL` / `NO_POOL_URL` constants from `useLatestPrices.js` (defined but never referenced; line 193 comment confirms YES/NO data is fetched via subgraph)
- Update fallback URL in `usePoolData.js` from `stag.api.tickspread.com` → `api.futarchy.fi`
- Add explicit `NEXT_PUBLIC_POOL_API_URL` env var in `netlify.toml` so the env wins over the fallback

## Notes
The endpoints called via `usePoolData.js` (e.g. `/api/v1/pools/volume`) are not yet exposed by the new `futarchy-api` deployment — those calls will 404 against `api.futarchy.fi` instead of timing out on a dead domain. Implementing those endpoints is a separate task.

## Test plan
- [ ] Netlify build succeeds
- [ ] No remaining references to `tickspread` in repo (`grep -r tickspread src/ app/ netlify.toml` returns nothing)