### PR TITLE
Fix /companies linkable proposals cutoff

### DIFF
--- a/futarchy-complete-sdk/src/cartridges/FutarchyCompleteCartridge.js
+++ b/futarchy-complete-sdk/src/cartridges/FutarchyCompleteCartridge.js
@@ -261,7 +261,7 @@ export class FutarchyCompleteCartridge {
         const SUBGRAPH_URL = getCandleSubgraph(chainId);
 
         const query = `{
-            proposals(first: 50, orderBy: id, orderDirection: desc) {
+            proposals(first: 1000, orderBy: id, orderDirection: desc) {
                 id
                 marketName
                 companyToken { symbol }


### PR DESCRIPTION
## Problem
The `/companies` page (admin UI for linking proposals to orgs) was missing recent proposals. For example, **GIP-150** (proposal `0xBA64...`, created today) didn't appear in the linkable list even though it exists on-chain and is indexed in the candles subgraph.

## Root cause
`getLinkableProposals` in `futarchy-complete-sdk/src/cartridges/FutarchyCompleteCartridge.js` queries the subgraph with:

```graphql
proposals(first: 50, orderBy: id, orderDirection: desc)
```

- The subgraph currently has **229 proposals**.
- Ordering by `id` (the proposal contract address) is effectively random — addresses are hex hashes, not creation order.
- GIP-150's id `0xba64...` lands at **position 73** in lex-desc order — past the `first: 50` cutoff.
- Net effect: any proposal whose hex id sorts below the top 50 is invisible to the admin UI.

## Fix
Bump the limit from 50 to 1000 (The Graph's hard cap). Covers all 229 current proposals with ~4x headroom.

## Why not order by `createdAt`?
The subgraph's `Proposal` type doesn't expose a `createdAt` / `blockNumber` field. Proper time-ordering would require adding one to the subgraph schema and redeploying — out of scope for this fix.

## Test plan
- [ ] Netlify build succeeds
- [ ] After deploy, `/companies` lists GIP-150 (`0xBA647181D5903769Ee464A4290A976B26FA079FE`) as a linkable proposal under Gnosis DAO