### PR TITLE
Fix 'Entity not found' on Manage Organization modal

### DIFF
--- a/src/components/debug/OrganizationManagerModal.jsx
+++ b/src/components/debug/OrganizationManagerModal.jsx
@@ -62,7 +62,7 @@ export default function OrganizationManagerModal({
             try {
                 const query = mode === MODE.AGGREGATOR
                     ? `{ aggregator(id: "${entityId.toLowerCase()}") { id name description metadata owner editor organizations { id name } } }`
-                    : `{ organization(id: "${entityId.toLowerCase()}") { id name description metadata owner editor proposals { id metadataContract } } }`;
+                    : `{ organization(id: "${entityId.toLowerCase()}") { id name description metadata owner editor proposals { metadataContract: id proposalAddress title } } }`;
 
                 const response = await fetch(SUBGRAPH_URL, {
                     method: 'POST',


### PR DESCRIPTION
## Problem
Opening "Manage Organization" for any org (e.g. Gnosis DAO) shows **"Entity not found"** even when the org clearly exists. This blocks all admin workflows that go through this modal — including linking new proposals (e.g. GIP-150) to an org.

## Root cause
The frontend GraphQL query in `OrganizationManagerModal.jsx:65` requests `proposals { id metadataContract }` from the aggregator subgraph. But `ProposalEntity` has no field called `metadataContract`. Actual fields are:

- `id` — the metadata contract address (what the rest of the component reads as `item.metadataContract`)
- `proposalAddress` — the on-chain trading proposal contract address

With an unknown field in the selection, the subgraph rejects the entire query. `result.data.organization` is then `undefined`, which trips the `setError('Entity not found')` branch on line 86.

## Fix
Alias `metadataContract: id` so the existing display/remove logic that reads `item.metadataContract` keeps working without further changes. Also fetch `proposalAddress` and `title` since they're directly useful for the list view.

## Verification
Tested the corrected query against the aggregator subgraph for Gnosis DAO — returns the org plus its 2 linked proposals (GIP-145 / GIP-149) cleanly.

```graphql
{ organization(id: "0x3fd2e8e71f75eed4b5c507706c413e33e0661bbf") {
    id name description owner editor
    proposals { metadataContract: id proposalAddress title }
} }
```

## Test plan
- [ ] After deploy, click "Manage Organization" on Gnosis DAO from `/companies` — modal loads with the 2 existing proposals listed
- [ ] Open same modal on other orgs (Aave DAO, CoW DAO, etc.) — also loads
- [ ] "+ Add Proposal" form still works (uses `targetAddress` from input, not from list items)