### PR TITLE
Filter archived proposals from companies and proposals lists

### DIFF
--- a/src/hooks/useAggregatorCompanies.js
+++ b/src/hooks/useAggregatorCompanies.js
@@ -67,9 +67,11 @@ function transformOrgToCard(org) {
     // Extract chainId from metadata (stored as string "1" or "100")
     const chainId = meta.chain ? parseInt(meta.chain, 10) : 100; // Default to Gnosis (100)
 
-    // Count active proposals (visibility !== 'hidden' AND not resolved)
-    // If no visibility is set, proposal is considered active (public)
-    const proposals = org.proposals || [];
+    // Count active proposals (not archived, not hidden, not resolved)
+    const proposals = (org.proposals || []).filter(p => {
+        const meta = parseMetadata(p.metadata);
+        return meta.archived !== true;
+    });
     const activeProposals = proposals.filter(proposal => {
         // Check metadataEntries for visibility key
         const visibilityEntry = proposal.metadataEntries?.find(e => e.key === 'visibility');

--- a/src/hooks/useAggregatorProposals.js
+++ b/src/hooks/useAggregatorProposals.js
@@ -410,6 +410,12 @@ export async function fetchProposalsFromAggregator(aggregatorAddress, connectedW
     const allProposals = [];
     for (const org of aggregator.organizations || []) {
         for (const proposal of org.proposals || []) {
+            // Skip archived proposals (test/abandoned, never going live)
+            const proposalMeta = parseMetadata(proposal.metadata);
+            if (proposalMeta.archived === true) {
+                console.log(`[🗄️ ARCHIVED] Skipping "${proposal.displayNameEvent?.slice(0, 40)}..."`);
+                continue;
+            }
             allProposals.push(transformProposalToEvent(proposal, org, connectedWallet));
         }
     }


### PR DESCRIPTION
## Summary
- Adds support for `archived: true` in on-chain proposal metadata
- Archived proposals are filtered out of active count and the aggregator fetch path used by Active Milestones, Resolved Events, and the Companies grid

## Why
Some on-chain proposals are test/abandoned markets that never went live (e.g. AAVE token alignment, CIP-83, and the broken GIP-150 with wrong-year timestamps). `visibility: 'hidden'` keeps them visible to owner/editor; `archived: true` removes them entirely from the public UI.

## Test plan
- [ ] On `/companies`, archived proposals do not contribute to the Active count
- [ ] On `/companies`, archived proposals do not appear in Active Milestones or Resolved Events
- [ ] Public proposals (`archived` unset or `false`) still display normally
- [ ] Hidden-but-not-archived proposals continue to be visible only to owner/editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)