### PR TITLE
Fix nonsense Liquidity widget value on market page

### DIFF
--- a/src/hooks/usePoolData.js
+++ b/src/hooks/usePoolData.js
@@ -108,28 +108,41 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
     }
   }
 
-  // Calculate Liquidity Value using Tick
-  // Price p = 1.0001^tick. SqrtPrice = 1.0001^(tick/2).
-  // Valued Liquidity ~ L * SqrtPrice (if quote is token 1).
+  // Convert Algebra V3 raw L to a currency-denominated TVL approximation.
+  //
+  // For a full-range position at the current price, the underlying token
+  // reserves are roughly amount0 ≈ L / sqrtPrice and amount1 ≈ L × sqrtPrice
+  // (in raw 1e18-scaled units when both tokens have 18 decimals). The total
+  // TVL valued in the currency token is therefore:
+  //
+  //   TVL_currency_wei ≈ amount_currency + amount_company × price
+  //                    = L × sqrtPrice + (L / sqrtPrice) × price
+  //                    = 2 × L × sqrtPrice         (since price = sqrtPrice²)
+  //
+  // We then divide by 1e18 to express it in currency-token units.
   let adjustedLiquidity = parseFloat(pool.liquidity || 0);
 
   try {
     if (pool.tick) {
-      // Calculate SqrtPrice from tick
       const tick = parseFloat(pool.tick);
-      // 1.0001 ^ (tick/2)
       const sqrtPrice = Math.pow(1.0001, tick / 2);
-
-      if (currencyIsToken0) {
-        // If currency is token 0, we divide by sqrtPrice? 
-        if (sqrtPrice > 0) adjustedLiquidity = adjustedLiquidity / sqrtPrice;
+      if (sqrtPrice > 0) {
+        const liquidityScaled = currencyIsToken0
+          ? adjustedLiquidity / sqrtPrice
+          : adjustedLiquidity * sqrtPrice;
+        // Both reserves at center → roughly 2× the single-side estimate;
+        // /1e18 to convert from raw token-scaled wei to currency units.
+        adjustedLiquidity = (liquidityScaled * 2) / 1e18;
       } else {
-        // Default (Token 1 is currency/quote)
-        adjustedLiquidity = adjustedLiquidity * sqrtPrice;
+        adjustedLiquidity = 0;
       }
+    } else {
+      // No tick available — fall back to raw-L /1e18 (best effort).
+      adjustedLiquidity = adjustedLiquidity / 1e18;
     }
   } catch (e) {
     console.warn('Error calculating tick-adjusted liquidity:', e);
+    adjustedLiquidity = 0;
   }
 
   // Derive company-token price from tick (price of company token in currency units)
@@ -154,9 +167,10 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
   return {
     volume: volumeTotal,
     liquidity: {
-      amount: adjustedLiquidity.toLocaleString('fullwide', { useGrouping: false }),
-      token: 'Raw',
-      isRaw: true
+      // Currency-denominated TVL (already normalized to token units, not wei).
+      amount: adjustedLiquidity.toString(),
+      token: proposalCurrencySymbol || 'sDAI',
+      isRaw: false
     },
     price
   };


### PR DESCRIPTION
## Summary

The market header's **Liquidity** widget rendered numbers like `200,003,226.96M` for a freshly-created pool with cents of TVL. Two compounding bugs in `usePoolData.formatSubgraphPoolData`:

1. **Wrong magnitude.** `adjustedLiquidity = L × sqrtPrice` was stashed as the liquidity amount. But Algebra V3's `liquidity` is uint128 *raw*, already scaled by 10¹⁸ when both tokens have 18 decimals — so the result was raw-wei magnitude (~10¹⁴), not a currency-denominated quantity.
2. **Wrong serialisation.** That value was emitted with `toLocaleString('fullwide')`, which keeps the fractional tail on non-integer floats (e.g. `"99963470353021.33"`). Downstream, `normalizeTokenAmount` treats any string containing `.` as "already in decimal form" and skips the `/1e18` wei conversion. So the raw 10¹⁴ value flowed straight through to the formatter.

Net effect: a pool with $0.0002 of seed TVL displayed a six-figure-millions number.

## Fix

In `formatSubgraphPoolData`, compute a proper full-range TVL approximation in currency units:

```
TVL ≈ 2 × L × sqrtPrice / 1e18    (when currency is token1)
TVL ≈ 2 × L / sqrtPrice / 1e18    (when currency is token0)
```

(For full-range positions at the current price, both sides hold roughly equal value, hence the `× 2`.) Emit it as a plain decimal string with `isRaw: false`.

## Testing

- [x] `next build` succeeds locally.
- [ ] On `/market?proposalId=0x1a0f209…` (GIP-150 v2, currently seeded only), the widget reads as a fraction of a cent instead of `200,003,226.96M`.
- [ ] After the Safe batch (477 GNO + 51,080 sDAI per side) executes, the widget reads roughly the right order of magnitude (~$126K total).

## Notes

- This is a *display* fix — the underlying L value in the subgraph is correct.
- The 2×-at-center approximation is fine for full-range Algebra V3 positions (which is what `setup-auto` and the Safe batch produce). Concentrated positions would need a more careful tick-aware calculation, but we don't use those here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)