### PR TITLE
Extract proposalId from milestones URL hash to fix swap quoter

### DIFF
--- a/src/pages/milestones.js
+++ b/src/pages/milestones.js
@@ -40,9 +40,24 @@ export default function MilestonesPage() {
       const currentHash = window.location.hash;
       setHash(currentHash);
 
-      // If the hash matches specific milestone patterns, show MarketPageShowcase instead
+      // If the hash matches specific milestone patterns, show MarketPageShowcase instead.
+      // Also extract the proposal address from `#milestone:0x...` / `#market:0x...` and
+      // surface it as `?proposalId=0x...`, since useContractConfig only reads the proposal
+      // ID from the path or query string — without it the swap quoter falls back to v1
+      // defaults and shows "Insufficient liquidity".
       if (currentHash.includes('milestone') || currentHash.includes('market')) {
         setShowMarket(true);
+
+        const hashAddrMatch = currentHash.match(/0x[a-fA-F0-9]{40}/);
+        const urlParams = new URLSearchParams(window.location.search);
+        if (hashAddrMatch && !urlParams.get('proposalId')) {
+          urlParams.set('proposalId', hashAddrMatch[0]);
+          window.history.replaceState(
+            {},
+            '',
+            window.location.pathname + '?' + urlParams.toString() + currentHash
+          );
+        }
       }
 
       // Map legacy numeric/slug company IDs to the on-chain Organization
@@ -110,7 +125,21 @@ export default function MilestonesPage() {
       const handleHashChange = () => {
         const newHash = window.location.hash;
         setHash(newHash);
-        setShowMarket(newHash.includes('milestone') || newHash.includes('market'));
+        const isMilestone = newHash.includes('milestone') || newHash.includes('market');
+        setShowMarket(isMilestone);
+
+        if (isMilestone) {
+          const hashAddrMatch = newHash.match(/0x[a-fA-F0-9]{40}/);
+          const urlParams = new URLSearchParams(window.location.search);
+          if (hashAddrMatch && urlParams.get('proposalId') !== hashAddrMatch[0]) {
+            urlParams.set('proposalId', hashAddrMatch[0]);
+            window.history.replaceState(
+              {},
+              '',
+              window.location.pathname + '?' + urlParams.toString() + newHash
+            );
+          }
+        }
       };
 
       window.addEventListener('hashchange', handleHashChange);


### PR DESCRIPTION
## Summary

- Surface fix for the YES side showing "Insufficient liquidity" on v2 markets
- Root cause: `/milestones?company_id=…#milestone:0x…` is the hash route into MarketPageShowcase, but milestones.js never extracted the `0x…` from the hash. MarketPageShowcase only reads `proposalId` from the path or query string, so it got nothing → useContractConfig returned a null config → ShowcaseSwapComponent fell into the Ethereum/Uniswap V3 quoter path with v1 fallback token addresses → revert → "Insufficient liquidity"
- This PR lifts the address out of `#milestone:0x…` / `#market:0x…` and writes it as `?proposalId=0x…` (via `history.replaceState`, no navigation) on first render and on `hashchange`, so the existing routing in MarketPageShowcase picks it up

## Test plan

- [ ] Open a deploy preview URL of the form `…/milestones?company_id=9#milestone:0x1a0f209Fa9730a4668cE43ce18982cb0010a972A` (GIP-150 v2)
- [ ] URL is rewritten to include `&proposalId=0x1a0f…`
- [ ] Console shows `[QUOTER SHOWCASE] Using FutarchyQuoteHelper (New Logic)` instead of `Using Uniswap QuoterV2 for Ethereum`
- [ ] Console shows `[QUOTER SHOWCASE] FutarchyQuoteHelper Result: { expectedReceive: 0.009… }`
- [ ] "If Yes" panel shows `0.01 GNO` (no "Insufficient liquidity")
- [ ] "If No" panel still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)