### PR TITLE
Lower FutarchyQuoteHelper gasLimit below Gnosis block cap

### DIFF
--- a/src/utils/FutarchyQuoteHelper.js
+++ b/src/utils/FutarchyQuoteHelper.js
@@ -44,8 +44,10 @@ export async function getSwapQuote({ proposal, amount, isYesPool, isInputCompany
     const inputType = isInputCompanyToken ? 0 : 1;
 
     // 3. Simulate (StaticCall is CRITICAL)
-    // We add gasLimit to be safe, though usually not needed if logic is clean.
-    const txOverrides = { gasLimit: 30000000 };
+    // The simulate call uses ~6.8M gas in practice. Stay below the Gnosis
+    // block gas limit (~17M) — public RPCs like gnosis-rpc.publicnode.com
+    // reject eth_call with gas > block limit ("Block gas limit exceeded").
+    const txOverrides = { gasLimit: 12_000_000 };
 
     let result;
     try {


### PR DESCRIPTION
## Summary

- Frontend swap quoter on Gnosis Chain was failing with "Insufficient liquidity" on every YES/NO panel for v2 markets
- Verified live on production via CDP that the helper revert was caused by the RPC, not the contract

## Root cause

`getSwapQuote()` calls `simulateQuote` with `gasLimit: 30_000_000`. Gnosis Chain block gas limit is ~17M. Public RPCs (`gnosis-rpc.publicnode.com` is in the priority list) reject `eth_call` when gas > block limit:

```
{"error":{"code":-32000,"message":"Block gas limit exceeded"}}
```

The simulation never reached the helper contract, so the catch branch in `ShowcaseSwapComponent` set `insufficientLiquidity: true`.

(`rpc.gnosischain.com` accepts 30M, which is why CLI scripts targeting that endpoint worked.)

In practice the helper uses ~6.8M gas. 12M is a safe ceiling — well above usage, well under the block cap.

## Test plan

- [ ] Open `/milestones?company_id=9#milestone:0x1a0f209Fa9730a4668cE43ce18982cb0010a972A` after the deploy preview lands
- [ ] Type `1` in the sDAI input
- [ ] Console shows `[QUOTER SHOWCASE] FutarchyQuoteHelper Result: { expectedReceive: 0.009… }` instead of `Simulation Failed`
- [ ] "If Yes" panel shows `0.01 GNO`, no "Insufficient liquidity"

🤖 Generated with [Claude Code](https://claude.com/claude-code)