### PR TITLE
Fix TWAP window for ended proposals

### DIFF
--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -536,16 +536,18 @@ const TwapCountdown = ({
     return providerRef.current;
   }, []);
 
-  const fetchPoolTwap = useCallback(async (poolConfig, secondsAgoStart, shouldInvert = null) => {
+  const fetchPoolTwap = useCallback(async (poolConfig, secondsAgoStart, shouldInvert = null, secondsAgoEnd = 0) => {
     if (!poolConfig?.address) {
       throw new Error('Missing pool address');
     }
-    const secondsWindow = Math.max(1, Math.floor(secondsAgoStart));
+    const aStart = Math.max(0, Math.floor(secondsAgoStart));
+    const aEnd = Math.max(0, Math.floor(secondsAgoEnd));
+    const secondsWindow = Math.max(1, aStart - aEnd);
     const provider = ensureProvider();
     const poolContract = new ethers.Contract(poolConfig.address, ALGEBRA_TWAP_ABI, provider);
-    const { tickCumulatives } = await poolContract.getTimepoints([secondsWindow, 0]);
-    const latest = BigInt(tickCumulatives[1].toString());
+    const { tickCumulatives } = await poolContract.getTimepoints([aStart, aEnd]);
     const oldest = BigInt(tickCumulatives[0].toString());
+    const latest = BigInt(tickCumulatives[1].toString());
     const tickDelta = latest - oldest;
     const averageTick = Number(tickDelta) / secondsWindow;
     const rawPrice = Math.pow(1.0001, averageTick);
@@ -628,12 +630,14 @@ const TwapCountdown = ({
         setTwapLoading(true);
         setTwapError(null);
         const now = Math.floor(Date.now() / 1000);
-        const timeSinceStart = Math.min(Math.max(now - twapStartTimestamp, 1), twapDurationSeconds);
-        const secondsAgoStart = hasEnded ? twapDurationSeconds : timeSinceStart;
+        const twapEndTimestamp = twapStartTimestamp + twapDurationSeconds;
+        // Active: [twapStart..now]. Ended: historical [twapStart..twapEnd], not the trailing 24h.
+        const secondsAgoStart = Math.max(1, now - twapStartTimestamp);
+        const secondsAgoEnd = hasEnded ? Math.max(0, now - twapEndTimestamp) : 0;
 
         const [yesPrice, noPrice] = await Promise.all([
-          fetchPoolTwap(yesPoolConfig, secondsAgoStart, invertTwapPoolYes),
-          fetchPoolTwap(noPoolConfig, secondsAgoStart, invertTwapPoolNo)
+          fetchPoolTwap(yesPoolConfig, secondsAgoStart, invertTwapPoolYes, secondsAgoEnd),
+          fetchPoolTwap(noPoolConfig, secondsAgoStart, invertTwapPoolNo, secondsAgoEnd)
         ]);
 
         if (cancelled) return;


### PR DESCRIPTION
## Summary

For closed proposals (`hasEnded`), `TwapCountdown.fetchPoolTwap` was querying `getTimepoints([24h_ago, 0])` — i.e. the TWAP over the **trailing 24 hours up to "now"** — instead of the **historical voting window**. After a proposal resolves, the conditional pools sit idle (no trades), so the trailing‑24h TWAP just reads back the post‑resolution price snapshot rather than the actual TWAP that decided the vote.

This makes the "Final TWAP Window" section show numbers that don't match what was on screen at close, and can flip the YES/NO winner display for proposals where the post-close pool state drifted.

## Repro (PNK / KIP‑81 — `0x2c1e08…481a`, resolved NO)

| | Frontend display (current) | Trailing‑24h TWAP (matches display) | Actual historical TWAP `[twapStart..twapEnd]` |
|---|---|---|---|
| YES | 0.009365 sDAI/PNK | tick=-46710 → 0.009365 | tick=-42046 → **0.0149** |
| NO  | 0.01289 sDAI/PNK  | tick=43512 → 0.01289 (inv) | tick=41861 → **0.01521** (inv) |

Correct historical numbers: YES 0.0149 / NO 0.01521 → NO ahead by ~2% (matches `resolution_outcome="no"`). Currently shown: -37.68% gap from stale post‑close state.

## Fix

`fetchPoolTwap` now takes an explicit `(secondsAgoStart, secondsAgoEnd)` window and calls `getTimepoints([secondsAgoStart, secondsAgoEnd])`. Caller passes:
- active: `[now - twapStart, 0]`
- ended:  `[now - twapStart, now - twapEnd]`

The inversion logic (`invertTwapPoolYes` / `invertTwapPoolNo` / `invertTwapPoolNO` fallback) is unchanged.

## Test plan
- [ ] Open a resolved proposal (e.g. PNK KIP‑81) and verify YES/NO TWAP values match the on-chain TWAP over the historical window, not the current pool snapshot
- [ ] Open an active proposal and verify the live TWAP still updates and matches `[twapStart..now]`
- [ ] Verify the % spread and "ahead on TWAP" indicator align with `resolution_outcome` for at least one resolved proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)