### PR TITLE
Add 404 redirect: /market/<addr> -> /market?proposalId=<addr>

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+
+// Match /market/<addr>, /markets/<addr>, /market/<addr>/, optional trailing slash
+// and preserve any query string / hash.
+const MARKET_PATH = /^\/markets?\/(0x[0-9a-fA-F]{40})\/?$/;
+
+export default function Custom404() {
+  const [redirecting, setRedirecting] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const m = window.location.pathname.match(MARKET_PATH);
+    if (!m) return;
+
+    const address = m[1];
+    const search = window.location.search || '';
+    const hash = window.location.hash || '';
+    const sep = search ? '&' : '?';
+    setRedirecting(true);
+    window.location.replace(`/market${search}${sep}proposalId=${address}${hash}`);
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>{redirecting ? 'Loading market…' : 'Page not found'} — Futarchy.fi</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <div className="flex flex-col items-center justify-center min-h-screen bg-white text-gray-800 px-6">
+        {redirecting ? (
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-futarchyLavender" />
+        ) : (
+          <div className="text-center max-w-md">
+            <h1 className="text-3xl font-bold mb-3">Page not found</h1>
+            <p className="text-gray-600 mb-6">
+              We couldn&apos;t find what you were looking for.
+            </p>
+            <Link href="/" className="text-futarchyBlue9 underline">Back to home</Link>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

`futarchy.fi/market/0x1a0f209Fa9730a4668cE43ce18982cb0010a972A` 404s today because:
- `pages/market.js` only matches the bare path `/market`
- `pages/markets/[address].js` (plural) only generates static paths for addresses listed in `src/config/markets.js`
- The site is statically exported (`output: 'export'`), so `next.config.mjs` redirects don't apply

This adds a `pages/404.js` that detects `/market/<addr>` or `/markets/<unconfigured-addr>` and client-side redirects to the canonical `/market?proposalId=<addr>`, preserving any query string or hash. Non-market 404s now render a proper "Page not found" view instead of blank.

Tested patterns:
- `/market/0x1a0f...` → `/market?proposalId=0x1a0f...` ✓
- `/markets/0x1a0f...` (unconfigured) → `/market?proposalId=0x1a0f...` ✓
- `/markets/0x45e1...` (configured GIP-145) → served directly, no 404 ✓
- `/market` → unchanged, redirects to default proposal ✓
- `/random` → renders 404 view ✓
- query/hash preserved (`/market/0x...#x` → `/market?proposalId=0x...#x`)

## Test plan
- [ ] Build & deploy preview, verify `/market/0x1a0f209Fa9730a4668cE43ce18982cb0010a972A` lands on the GIP-150 v2 page
- [ ] `/markets/0x45e1064348fD8A407D6D1F59Fc64B05F633b28FC` still works directly (configured market)
- [ ] `/some/random/path` shows the new 404 view

🤖 Generated with [Claude Code](https://claude.com/claude-code)