### PR TITLE
Add Arbitrage Contract badge; default-hide Prediction Market behind metadata flag

### DIFF
--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -4969,15 +4969,27 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
                     });
                   }
 
-                  // Prediction Market badge
-                  if (config?.BASE_TOKENS_CONFIG?.currency?.address && (
-                    config?.MERGE_CONFIG?.currencyPositions?.yes?.wrap?.wrappedCollateralTokenAddress ||
-                    config?.MERGE_CONFIG?.currencyPositions?.no?.wrap?.wrappedCollateralTokenAddress
-                  )) {
+                  // Prediction Market badge — opt-in via metadata flag (default off).
+                  if (
+                    config?.marketInfo?.showPredictionMarket === true &&
+                    config?.BASE_TOKENS_CONFIG?.currency?.address && (
+                      config?.MERGE_CONFIG?.currencyPositions?.yes?.wrap?.wrappedCollateralTokenAddress ||
+                      config?.MERGE_CONFIG?.currencyPositions?.no?.wrap?.wrappedCollateralTokenAddress
+                    )
+                  ) {
                     badges.push({
                       text: 'Prediction Market',
                       colorScheme: 'default',
                       onClick: () => setIsPredictionMarketModalOpen(true)
+                    });
+                  }
+
+                  // Arbitrage Contract badge — links to Gnosisscan when set in metadata.
+                  if (config?.marketInfo?.arbitrageContractAddress) {
+                    badges.push({
+                      text: 'Arbitrage Contract',
+                      colorScheme: 'default',
+                      link: `https://gnosisscan.io/address/${config.marketInfo.arbitrageContractAddress}`
                     });
                   }
 

--- a/src/components/futarchyFi/marketPage/components/MarketBadge.jsx
+++ b/src/components/futarchyFi/marketPage/components/MarketBadge.jsx
@@ -29,7 +29,7 @@ const MarketBadge = ({ text, colorScheme = 'default', link, onClick }) => {
   const commonClasses = `h-7 py-1 px-3 text-sm font-semibold rounded-lg border-2 flex items-center justify-center gap-1 transition-colors duration-200 whitespace-nowrap`;
 
   // Apply a more subtle glow effect only to interactive badges
-  const interactiveBadges = ['Market Summary', 'Track Progress', 'Prediction Market', 'Resolve Question', 'Add Liquidity'];
+  const interactiveBadges = ['Market Summary', 'Track Progress', 'Prediction Market', 'Resolve Question', 'Add Liquidity', 'Arbitrage Contract'];
   const isInteractive = interactiveBadges.includes(text) || link || onClick;
 
   const glowClass = isInteractive ? 'animate-subtle-pulse drop-shadow-[0_0_2px_rgba(255,255,255,0.4)]' : '';

--- a/src/hooks/useContractConfig.js
+++ b/src/hooks/useContractConfig.js
@@ -484,6 +484,10 @@ export const useContractConfig = (proposalId, forceTestPools = false) => {
             closeTimestamp: data._registryMetadata?.closeTimestamp || null,
             // Include track progress link from metadata
             trackProgressLink: metadata?.trackProgressLink || null,
+            // Off-by-default: only show the Prediction Market badge when explicitly enabled
+            showPredictionMarket: metadata?.showPredictionMarket === true,
+            // Optional arbitrage contract for this proposal — exposed as a Gnosisscan link
+            arbitrageContractAddress: metadata?.arbitrageContractAddress || null,
             // Include question link from metadata (check both nested and direct paths)
             questionLink: metadata?.metadata?.question_link || metadata?.questionLink || null,
             // Add resolved status - only resolved if there's an actual outcome or resolution_status indicates completion


### PR DESCRIPTION
## Summary

Two small changes to the market header badge row:

1. **New "Arbitrage Contract" badge** — when proposal metadata contains `arbitrageContractAddress`, render a badge that links to `https://gnosisscan.io/address/<addr>` (opens in new tab, follows existing `link`-badge pattern).
2. **Prediction Market badge is now opt-in** — gated on `metadata.showPredictionMarket === true`. Previously it appeared automatically whenever the proposal had prediction-pool config, which we now want off by default.

Both fields are plumbed through `useContractConfig.js` into `marketInfo`.

## Behavior

| Metadata | Prediction Market | Arbitrage Contract |
|---|---|---|
| (neither set) | hidden | hidden |
| `showPredictionMarket: true` | shown | hidden |
| `arbitrageContractAddress: 0x…` | hidden | shown |
| both | shown | shown |

## Test plan
- [ ] Open a market with neither flag set — neither badge appears
- [ ] Add `arbitrageContractAddress` to a proposal's metadata, reload — Arbitrage Contract badge appears, click goes to Gnosisscan
- [ ] Add `showPredictionMarket: true` to metadata — Prediction Market badge appears with the existing modal
- [ ] Verify the badge order in the row is unchanged for previously-rendered badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)