### PR TITLE
HOTFIX: TDZ crash on every market page

### DIFF
--- a/src/components/futarchyFi/marketPage/ConfirmSwapModal.jsx
+++ b/src/components/futarchyFi/marketPage/ConfirmSwapModal.jsx
@@ -699,75 +699,6 @@ const ConfirmSwapModal = memo(({
     const pollingRetryCountRef = useRef(0);
     const MAX_POLLING_ATTEMPTS = 5;
 
-    // Hide the "Max Approval" section when input-token allowances for the
-    // spenders this swap will touch are already effectively unlimited — the
-    // toggle has no effect because no `approve` tx will be sent.
-    useEffect(() => {
-        if (!publicClient || !account || !transactionData?.action) return;
-        const baseTokenConfig = config?.BASE_TOKENS_CONFIG || BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG;
-        const mergeConfig = config?.MERGE_CONFIG || MERGE_CONFIG || DEFAULT_MERGE_CONFIG;
-        const futarchyRouter = config?.FUTARCHY_ROUTER_ADDRESS || FUTARCHY_ROUTER_ADDRESS;
-        if (!baseTokenConfig?.currency?.address || !mergeConfig?.currencyPositions || !futarchyRouter) return;
-
-        const isYes = transactionData.outcome === 'Event Will Occur';
-        const condCurrency = isYes
-            ? mergeConfig.currencyPositions?.yes?.wrap?.wrappedCollateralTokenAddress
-            : mergeConfig.currencyPositions?.no?.wrap?.wrappedCollateralTokenAddress;
-        const condCompany = isYes
-            ? mergeConfig.companyPositions?.yes?.wrap?.wrappedCollateralTokenAddress
-            : mergeConfig.companyPositions?.no?.wrap?.wrappedCollateralTokenAddress;
-
-        // Pairs the swap path will need allowance for, by action.
-        // Buy:  base currency → futarchyRouter (split), conditional currency → swap router.
-        // Sell: conditional company → swap router, conditional currency → futarchyRouter (merge).
-        let pairs = [];
-        if (transactionData.action === 'Buy') {
-            pairs = [
-                { token: baseTokenConfig.currency.address, spender: futarchyRouter },
-                { token: condCurrency, spender: SWAPR_V3_ROUTER },
-            ];
-        } else if (transactionData.action === 'Sell') {
-            pairs = [
-                { token: condCompany, spender: SWAPR_V3_ROUTER },
-                { token: condCurrency, spender: futarchyRouter },
-            ];
-        } else {
-            setHideApprovalSection(false);
-            return;
-        }
-        pairs = pairs.filter(p => p.token && p.spender);
-        if (pairs.length === 0) {
-            setHideApprovalSection(false);
-            return;
-        }
-
-        let cancelled = false;
-        const ALLOWANCE_ABI = [{
-            name: 'allowance', type: 'function', stateMutability: 'view',
-            inputs: [{ name: '', type: 'address' }, { name: '', type: 'address' }],
-            outputs: [{ type: 'uint256' }],
-        }];
-        const HALF_MAX = ethers.constants.MaxUint256.div(2);
-
-        (async () => {
-            try {
-                const allowances = await Promise.all(pairs.map(p =>
-                    publicClient.readContract({
-                        address: p.token,
-                        abi: ALLOWANCE_ABI,
-                        functionName: 'allowance',
-                        args: [account, p.spender],
-                    }).catch(() => 0n)
-                ));
-                const allMax = allowances.every(a => ethers.BigNumber.from(a.toString()).gte(HALF_MAX));
-                if (!cancelled) setHideApprovalSection(allMax);
-            } catch {
-                if (!cancelled) setHideApprovalSection(false);
-            }
-        })();
-        return () => { cancelled = true; };
-    }, [publicClient, account, transactionData?.action, transactionData?.outcome, config, FUTARCHY_ROUTER_ADDRESS]);
-
     // Define backdrop variants for Framer Motion
     const backdropVariants = {
         hidden: { opacity: 0 },
@@ -921,6 +852,77 @@ const ConfirmSwapModal = memo(({
         // ---> Destructure network config with default <---
         network: networkConfig = {}
     } = config || {};
+
+    // Hide the "Max Approval" section when input-token allowances for the
+    // spenders this swap will touch are already effectively unlimited.
+    // (Must come after `config` and `FUTARCHY_ROUTER_ADDRESS` are in scope —
+    // referencing them in the deps array before initialization causes a TDZ
+    // error that crashes the entire page during render.)
+    useEffect(() => {
+        if (!publicClient || !account || !transactionData?.action) return;
+        const baseTokenConfig = config?.BASE_TOKENS_CONFIG || BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG;
+        const mergeConfig = config?.MERGE_CONFIG || MERGE_CONFIG;
+        const futarchyRouter = config?.FUTARCHY_ROUTER_ADDRESS || FUTARCHY_ROUTER_ADDRESS;
+        if (!baseTokenConfig?.currency?.address || !mergeConfig?.currencyPositions || !futarchyRouter) return;
+
+        const isYes = transactionData.outcome === 'Event Will Occur';
+        const condCurrency = isYes
+            ? mergeConfig.currencyPositions?.yes?.wrap?.wrappedCollateralTokenAddress
+            : mergeConfig.currencyPositions?.no?.wrap?.wrappedCollateralTokenAddress;
+        const condCompany = isYes
+            ? mergeConfig.companyPositions?.yes?.wrap?.wrappedCollateralTokenAddress
+            : mergeConfig.companyPositions?.no?.wrap?.wrappedCollateralTokenAddress;
+
+        // Pairs the swap path will need allowance for, by action.
+        // Buy:  base currency → futarchyRouter (split), conditional currency → swap router.
+        // Sell: conditional company → swap router, conditional currency → futarchyRouter (merge).
+        let pairs = [];
+        if (transactionData.action === 'Buy') {
+            pairs = [
+                { token: baseTokenConfig.currency.address, spender: futarchyRouter },
+                { token: condCurrency, spender: SWAPR_V3_ROUTER },
+            ];
+        } else if (transactionData.action === 'Sell') {
+            pairs = [
+                { token: condCompany, spender: SWAPR_V3_ROUTER },
+                { token: condCurrency, spender: futarchyRouter },
+            ];
+        } else {
+            setHideApprovalSection(false);
+            return;
+        }
+        pairs = pairs.filter(p => p.token && p.spender);
+        if (pairs.length === 0) {
+            setHideApprovalSection(false);
+            return;
+        }
+
+        let cancelled = false;
+        const ALLOWANCE_ABI = [{
+            name: 'allowance', type: 'function', stateMutability: 'view',
+            inputs: [{ name: '', type: 'address' }, { name: '', type: 'address' }],
+            outputs: [{ type: 'uint256' }],
+        }];
+        const HALF_MAX = ethers.constants.MaxUint256.div(2);
+
+        (async () => {
+            try {
+                const allowances = await Promise.all(pairs.map(p =>
+                    publicClient.readContract({
+                        address: p.token,
+                        abi: ALLOWANCE_ABI,
+                        functionName: 'allowance',
+                        args: [account, p.spender],
+                    }).catch(() => 0n)
+                ));
+                const allMax = allowances.every(a => ethers.BigNumber.from(a.toString()).gte(HALF_MAX));
+                if (!cancelled) setHideApprovalSection(allMax);
+            } catch {
+                if (!cancelled) setHideApprovalSection(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [publicClient, account, transactionData?.action, transactionData?.outcome, config, FUTARCHY_ROUTER_ADDRESS]);
 
     // Create a console log for debugging
     console.log('🔄 ConfirmSwapModal config status:', {


### PR DESCRIPTION
## Critical: blocks all market pages from loading

PR #57 placed a `useEffect` at line ~702 of `ConfirmSwapModal.jsx` with `config` and `FUTARCHY_ROUTER_ADDRESS` in its deps array. Both bindings come from a `useContractConfig()` hook + destructure at line ~905. React evaluates the deps array on every render — so on first render the deps array referenced bindings that hadn't been initialized yet (TDZ).

After minification:
```
useEffect(...,[tD, tS, ...?en.action, ...?en.outcome, tP, tR]);  // tP=config, tR=FUTARCHY_ROUTER_ADDRESS
```

Result: `ReferenceError: Cannot access 'tP' before initialization` thrown synchronously during render → entire React tree fails to mount → page shows the Next.js "Application error: a client-side exception has occurred."

Reproduced on the GIP-150 v2 page (Martin), and structurally affects every page that mounts `ConfirmSwapModal` (i.e. every market). The dev server may have masked it via different ordering of strict-mode renders.

## Fix

Move the entire effect to immediately after the `config` destructure (line ~923 → effect now at line 856). Also drop a stray `|| DEFAULT_MERGE_CONFIG` fallback that was an undefined reference (flagged in PR #57's original diagnostics, harmless because the `||` short-circuits, removing for cleanliness).

## Test plan
- [ ] Deploy preview loads `/market?proposalId=0x1a0f209fa9730a4668ce43ce18982cb0010a972a` without console errors
- [ ] Confirm GIP-145 page (`/markets/0x45e1064348fD8A407D6D1F59Fc64B05F633b28FC`) still loads
- [ ] Open swap modal on a market with non-max approvals → Max Approval section visible
- [ ] Open swap modal on a market where input token has unlimited allowance → section hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)