### PR TITLE
fix(ui): allow text selection across all pages

### DIFF
--- a/src/components/layout/PageLayout.jsx
+++ b/src/components/layout/PageLayout.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const PageLayout = ({ hero, children, contentClassName = '' }) => {
   return (
-    <div className="flex flex-col select-none flex-grow">
+    <div className="flex flex-col flex-grow">
       {/* 1. Hero Section (Optional) */}
       {hero && (
         <header>


### PR DESCRIPTION
## Summary

Removes the blanket `select-none` on the `PageLayout` root container so users can actually select and copy text from the app.

Reported issue: on https://futarchy.fi/companies (and elsewhere), text like "No upcoming events" cannot be selected. The cause is a single `select-none` Tailwind class on the layout that wraps Companies, Proposals, Market, MarketShowcase, and other top-level pages.

There is no UX reason for the global rule — it likely got added once to suppress accidental selection during a drag/swipe interaction in a single component. Components that legitimately need to suppress selection still apply `select-none` locally; this PR only removes the global one.

## Files

- `src/components/layout/PageLayout.jsx` — drop `select-none` from the root flex container

## Test plan

- [ ] On `/companies`, `/proposals`, and a market page, drag-select any text and confirm the highlight appears
- [ ] Confirm copy-to-clipboard works (cmd+C) on a span of selected text
- [ ] Sanity-check the carousel components (EventsHighlightCarousel, ResolvedEventsCarousel) — swipe gestures still work in mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)