### PR TITLE
fix(companies): show YES/NO prices on Companies card

### DIFF
--- a/src/hooks/useAggregatorProposals.js
+++ b/src/hooks/useAggregatorProposals.js
@@ -312,8 +312,11 @@ async function bulkFetchPoolsByChain(proposals) {
     const poolMap = {};
     for (const pool of result?.data?.pools || []) {
         if (pool.type !== 'CONDITIONAL' && pool.type !== 'conditional') continue;
-        // Strip "<chainId>-" prefix to key by plain proposal address
-        const propAddr = (pool.proposal || '').split('-').slice(1).join('-').toLowerCase();
+        // Key by plain proposal address. The /candles/graphql proxy already
+        // strips the "<chainId>-" prefix from response IDs, so handle both
+        // shapes (prefixed for direct upstream, plain for proxied).
+        const raw = (pool.proposal || '').toLowerCase();
+        const propAddr = raw.includes('-') ? raw.split('-').slice(1).join('-') : raw;
         if (!propAddr) continue;
         if (!poolMap[propAddr]) poolMap[propAddr] = { yes: null, no: null };
         if (pool.outcomeSide === 'YES' || pool.outcomeSide === 'yes') {


### PR DESCRIPTION
## Summary

The Companies page card was showing **YES Price 0.00 SDAI / NO Price 0.00 SDAI / Impact N/A** for GIP-150 even though the market page correctly displayed Impact +3.45% for the same proposal.

Root cause: \`bulkFetchPoolsByChain\` (used by the Companies/Active Milestones flow but not by the market page) tried to strip a \`"<chainId>-"\` prefix from \`pool.proposal\` via \`split('-').slice(1).join('-')\`. But the \`/candles/graphql\` proxy *already* normalizes response IDs by stripping that prefix. So:

- pool.proposal = \`"0x1a0f209f..."\` (no dash)
- \`.split('-').slice(1).join('-')\` → \`""\`
- \`if (!propAddr) continue\` → every pool skipped
- \`poolMap\` empty → \`proposal.poolAddresses\` never set → carousel had nothing to bulk-fetch prices for

The market page works because it uses \`subgraphConfigAdapter\` (rewritten in PR #62), which is a totally different code path.

## Fix

Only slice off the prefix when a dash is actually present. One line, defensive against both proxied and direct upstream responses.

## Test plan
- [ ] After deploy, visit https://futarchy.fi/companies — GIP-150 card should show non-zero YES/NO prices and Impact ≈ +3.45%
- [ ] Other Active Milestones cards should also populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)