### PR TITLE
fix(market-page): chart 502 + Volume/Liquidity 0 (Checkpoint shape)

### DIFF
--- a/src/hooks/usePoolData.js
+++ b/src/hooks/usePoolData.js
@@ -20,45 +20,56 @@ const API_BASE_URL = normalizeBaseUrl(RAW_API_BASE_URL);
 
 console.log('Pool API URL configured as:', API_BASE_URL);
 
-const PROPOSAL_POOLS_QUERY = `
-  query GetProposalPools($proposalId: ID!) {
-    proposal(id: $proposalId) {
-      currencyToken { symbol }
-      pools {
-        id
-        outcomeSide
-        type
-        liquidity
-        volumeToken0
-        volumeToken1
-        token0 { symbol decimals role }
-        token1 { symbol decimals role }
-        tick
-      }
-    }
+// Checkpoint indexer shape: no nested entity refs (proposal, token0/token1
+// and currencyToken are flat string fields), no Proposal.pools reverse field,
+// no BigInt scalar. We assemble the equivalent shape with three flat top-level
+// queries in a single request and join in JS using a whitelistedtokens map.
+const buildProposalPoolsQuery = (proposalId) => `{
+  proposal(id: "${proposalId}") {
+    id
+    currencyToken
+    companyToken
   }
-`;
+  whitelistedtokens(where: { proposal: "${proposalId}" }, first: 100) {
+    address
+    symbol
+    decimals
+    role
+  }
+  pools(where: { proposal: "${proposalId}" }, first: 100) {
+    id
+    outcomeSide
+    type
+    liquidity
+    volumeToken0
+    volumeToken1
+    token0
+    token1
+    tick
+  }
+}`;
 
-const POOL_QUERY = `
-  query GetPoolData($poolId: ID!, $timestamp24hAgo: BigInt!) {
-    pool(id: $poolId) {
-      id
-      liquidity
-      volumeToken0
-      volumeToken1
-      token0 { symbol decimals role }
-      token1 { symbol decimals role }
-      tick
-    }
-    candles(
-      where: { pool: $poolId, time_gte: $timestamp24hAgo, period: 3600 }
-      orderBy: time
-      orderDirection: desc
-    ) {
-      volumeUSD
-    }
+const buildPoolQuery = (poolId) => `{
+  pool: pools(where: { id: "${poolId}" }, first: 1) {
+    id
+    liquidity
+    volumeToken0
+    volumeToken1
+    token0
+    token1
+    tick
+    proposal
   }
-`;
+}`;
+
+const buildTokensForPoolQuery = (proposalId) => `{
+  whitelistedtokens(where: { proposal: "${proposalId}" }, first: 100) {
+    address
+    symbol
+    decimals
+    role
+  }
+}`;
 
 // Helper to format a raw subgraph pool into our app's data structure
 const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
@@ -84,26 +95,33 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
     return t.symbol?.toLowerCase() === proposalCurrencySymbol.toLowerCase();
   };
 
+  // Checkpoint stores volumeToken0/1 as raw token-decimal strings (e.g.
+  // "6153878689256497859232" for ~6153.88 sDAI at 18 decimals). Divide
+  // by 10^decimals to express in human units.
+  const toHuman = (raw, dec) => parseFloat(raw || 0) / Math.pow(10, dec ?? 18);
+  const vol0 = toHuman(pool.volumeToken0, t0.decimals);
+  const vol1 = toHuman(pool.volumeToken1, t1.decimals);
+
   // Check Token 0
   if (isCurrencyRole(t0) || isCurrencySymbol(t0)) {
-    volumeTotal += parseFloat(pool.volumeToken0 || 0);
+    volumeTotal += vol0;
     currencyIsToken0 = true;
   }
 
   // Check Token 1
   if (isCurrencyRole(t1) || isCurrencySymbol(t1)) {
-    volumeTotal += parseFloat(pool.volumeToken1 || 0);
+    volumeTotal += vol1;
     currencyIsToken1 = true;
   }
 
   // Fallback if no clear currency
   if (volumeTotal === 0 && !currencyIsToken0 && !currencyIsToken1) {
-    const isCommonStable = (s) => s.includes('DAI') || s.includes('USDC');
-    if (isCommonStable(t0.symbol)) { volumeTotal += parseFloat(pool.volumeToken0 || 0); currencyIsToken0 = true; }
-    else if (isCommonStable(t1.symbol)) { volumeTotal += parseFloat(pool.volumeToken1 || 0); currencyIsToken1 = true; }
+    const isCommonStable = (s) => s?.includes('DAI') || s?.includes('USDC');
+    if (isCommonStable(t0.symbol)) { volumeTotal += vol0; currencyIsToken0 = true; }
+    else if (isCommonStable(t1.symbol)) { volumeTotal += vol1; currencyIsToken1 = true; }
     else {
       // Blind default: Assume Token 1 is currency (standard for most pairs)
-      volumeTotal += parseFloat(pool.volumeToken1 || 0);
+      volumeTotal += vol1;
       currencyIsToken1 = true;
     }
   }
@@ -195,8 +213,7 @@ const fetchBestPoolsForProposal = async (proposalId, chainId = 100) => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        query: PROPOSAL_POOLS_QUERY,
-        variables: { proposalId: proposalId.toLowerCase() }
+        query: buildProposalPoolsQuery(proposalId.toLowerCase())
       })
     });
 
@@ -206,8 +223,35 @@ const fetchBestPoolsForProposal = async (proposalId, chainId = 100) => {
       return null;
     }
 
-    const pools = result.data.proposal.pools || [];
-    const currencySymbol = result.data.proposal.currencyToken?.symbol;
+    // Build a token map keyed by lowercased address, derived from
+    // whitelistedtokens. Used to enrich each pool's flat token0/token1
+    // address strings with { symbol, decimals, role } so the downstream
+    // formatter (which expects Graph-Node-shaped objects) keeps working.
+    const wls = result.data.whitelistedtokens || [];
+    const tokenByAddr = new Map();
+    for (const t of wls) {
+      if (!t.address) continue;
+      tokenByAddr.set(t.address.toLowerCase(), {
+        symbol: t.symbol || null,
+        decimals: t.decimals ?? 18,
+        role: t.role || null,
+      });
+    }
+    const enrichToken = (addr) => {
+      const lc = (addr || '').toLowerCase();
+      const meta = tokenByAddr.get(lc) || { symbol: null, decimals: 18, role: null };
+      return { id: lc, ...meta };
+    };
+
+    // Derive currencySymbol from any *_CURRENCY whitelistedtoken.
+    const currencyMeta = wls.find(t => t.role === 'YES_CURRENCY' || t.role === 'NO_CURRENCY');
+    const currencySymbol = currencyMeta?.symbol?.replace(/^(YES|NO)_/i, '') || null;
+
+    const pools = (result.data.pools || []).map(p => ({
+      ...p,
+      token0: enrichToken(p.token0),
+      token1: enrichToken(p.token1),
+    }));
 
     console.log(`[Pool Data] Found ${pools.length} pools for proposal on chain ${chainId}`);
 
@@ -290,19 +334,11 @@ const fetchSubgraphPoolData = async (poolId, chainId = 100) => {
       return null;
     }
 
-    const timestamp24hAgo = Math.floor(Date.now() / 1000) - 24 * 60 * 60;
-
     // Use native fetch instead of graphql-request
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: POOL_QUERY,
-        variables: {
-          poolId: poolId.toLowerCase(),
-          timestamp24hAgo: timestamp24hAgo.toString() // BigInt requires string input
-        }
-      })
+      body: JSON.stringify({ query: buildPoolQuery(poolId.toLowerCase()) })
     });
 
     const result = await response.json();
@@ -312,10 +348,43 @@ const fetchSubgraphPoolData = async (poolId, chainId = 100) => {
       return null;
     }
 
-    const data = result.data;
-    if (!data || !data.pool) return null;
+    const pool = result.data?.pool?.[0];
+    if (!pool) return null;
 
-    return formatSubgraphPoolData(data.pool);
+    // Resolve token symbols/decimals/roles via the proposal's whitelistedtokens.
+    // proposal comes back from the proxy as a plain (already chain-prefix-stripped)
+    // address string in Checkpoint mode.
+    const proposalAddr = (pool.proposal || '').toLowerCase();
+    let tokenByAddr = new Map();
+    if (proposalAddr) {
+      try {
+        const tokensResp = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: buildTokensForPoolQuery(proposalAddr) })
+        });
+        const tokensJson = await tokensResp.json();
+        for (const t of tokensJson.data?.whitelistedtokens || []) {
+          if (!t.address) continue;
+          tokenByAddr.set(t.address.toLowerCase(), {
+            symbol: t.symbol || null,
+            decimals: t.decimals ?? 18,
+            role: t.role || null,
+          });
+        }
+      } catch (_) { /* fall through with empty map */ }
+    }
+    const enrichToken = (addr) => {
+      const lc = (addr || '').toLowerCase();
+      const meta = tokenByAddr.get(lc) || { symbol: null, decimals: 18, role: null };
+      return { id: lc, ...meta };
+    };
+
+    return formatSubgraphPoolData({
+      ...pool,
+      token0: enrichToken(pool.token0),
+      token1: enrichToken(pool.token1),
+    });
 
 
   } catch (error) {

--- a/src/hooks/useSubgraphData.js
+++ b/src/hooks/useSubgraphData.js
@@ -3,35 +3,45 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { SUBGRAPH_ENDPOINTS } from '../config/subgraphEndpoints';
 
-// GraphQL queries - combined into single query for efficiency
-const QUERIES = {
-    // Single query to get pools AND their candles in one request
-    // period: 3600 = 1 hour candles (60=1m, 300=5m, 900=15m, 3600=1h, 86400=1d)
-    GET_POOLS_WITH_CANDLES: `
-    query GetPoolsWithCandles($proposalId: String!, $limit: Int!, $period: BigInt!, $closeTimestamp: BigInt!) {
-      pools(where: { proposal: $proposalId, type: "CONDITIONAL" }) {
+// Build queries for the Checkpoint indexer (no BigInt scalar; candles aren't
+// a reverse field on Pool; proposal/pool are flat string IDs that the
+// /candles/graphql proxy chain-prefixes when matched as inline literals).
+//
+// We inline the proposal ID and pool IDs as string literals so the proxy
+// regex (which only rewrites literals like `proposal: "0x…"`) picks them
+// up — variables like $proposalId aren't in the proxy's prefix list.
+function buildPoolsQuery(proposalId) {
+    return `{
+      pools(where: { proposal: "${proposalId}", type: "CONDITIONAL" }) {
         id
         name
         type
         outcomeSide
         price
         isInverted
-        proposal {
-          id
-          marketName
-        }
-        candles(first: $limit, orderBy: periodStartUnix, orderDirection: desc, where: { period: $period, periodStartUnix_lte: $closeTimestamp }) {
-          periodStartUnix
-          period
-          open
-          high
-          low
-          close
-        }
       }
-    }
-  `
-};
+    }`;
+}
+
+function buildCandlesQuery(poolIds, limit, closeTimestamp) {
+    const idList = poolIds.map(id => `"${id}"`).join(', ');
+    return `{
+      candles(
+        first: ${limit},
+        orderBy: periodStartUnix,
+        orderDirection: desc,
+        where: { pool_in: [${idList}], period: 3600, periodStartUnix_lte: ${closeTimestamp} }
+      ) {
+        pool
+        periodStartUnix
+        period
+        open
+        high
+        low
+        close
+      }
+    }`;
+}
 
 // Module-level cache to prevent double fetches from React Strict Mode
 const fetchCache = new Map();
@@ -176,12 +186,11 @@ export function useSubgraphData(proposalId, chainId, candleLimit = 500, closeTim
         // Create promise and cache it
         const fetchPromise = (async () => {
             try {
-                const poolsData = await executeQuery(endpoint, QUERIES.GET_POOLS_WITH_CANDLES, {
-                    proposalId: proposalId.toLowerCase(),
-                    limit: candleLimit,
-                    period: "3600",  // 1 hour candles (BigInt passed as string)
-                    closeTimestamp: closeTimestamp ? closeTimestamp.toString() : Math.floor(Date.now() / 1000).toString()
-                });
+                // Step 1 — fetch CONDITIONAL pools for this proposal.
+                const poolsData = await executeQuery(
+                    endpoint,
+                    buildPoolsQuery(proposalId.toLowerCase())
+                );
 
                 const pools = poolsData.pools || [];
                 const yesPool = pools.find(p => p.outcomeSide === 'YES') || null;
@@ -201,9 +210,31 @@ export function useSubgraphData(proposalId, chainId, candleLimit = 500, closeTim
                     return emptyResult;
                 }
 
-                // Transform data from the pool's nested candles - PURE subgraph data, no artificial stretching
-                const yesData = yesPool ? adaptCandlesToChartFormat(yesPool.candles) : [];
-                const noData = noPool ? adaptCandlesToChartFormat(noPool.candles) : [];
+                // Step 2 — fetch candles for those pools in one batched query.
+                // Checkpoint has no Pool.candles reverse field, so we query
+                // candles directly and group by pool address.
+                const poolIds = [yesPool, noPool].filter(Boolean).map(p => p.id);
+                const candlesCutoff = closeTimestamp
+                    ? Number(closeTimestamp)
+                    : Math.floor(Date.now() / 1000);
+
+                const candlesData = await executeQuery(
+                    endpoint,
+                    buildCandlesQuery(poolIds, candleLimit, candlesCutoff)
+                );
+
+                const yesCandles = [];
+                const noCandles = [];
+                const yesId = (yesPool?.id || '').toLowerCase();
+                const noId = (noPool?.id || '').toLowerCase();
+                for (const c of candlesData.candles || []) {
+                    const poolAddr = (c.pool || '').toLowerCase();
+                    if (poolAddr === yesId) yesCandles.push(c);
+                    else if (poolAddr === noId) noCandles.push(c);
+                }
+
+                const yesData = adaptCandlesToChartFormat(yesCandles);
+                const noData = adaptCandlesToChartFormat(noCandles);
 
                 // Get latest prices from the last candle (pure data, no artificial live candle)
                 const yesPrice = yesData.length > 0


### PR DESCRIPTION
## Summary

The market page (e.g. GIP-150) showed:
- **Chart panel**: \`Subgraph request failed: 502\`
- **Stat row**: \`Volume (Total; sDAI) 0\`, \`Liquidity 0\`, empty YES/NO prices

Two hooks were still issuing **Graph Node**-shaped queries against the Checkpoint indexer behind \`api.futarchy.fi/candles/graphql\`. The proxy can translate IDs and field names but can't synthesize fields that don't exist (\`BigInt\`, reverse relations, nested entity selections on scalars), so the upstream errors surfaced as 502s and the consumers fell back to zero/empty values.

### Errors found and reproduced
\`\`\`
Unknown type "BigInt". Did you mean "Int"?
Field "currencyToken" must not have a selection since type "String!" has no subfields.
\`\`\`

## Fix

**\`src/hooks/useSubgraphData.js\`** (chart candles)
- Removed \`BigInt\` variables — use Int literals
- Split combined \`pools { candles { … } }\` query into separate pools + candles queries (Checkpoint has no \`Pool.candles\` reverse field), join in JS by pool address
- Removed nested \`proposal { id marketName }\` selection
- Inlined IDs as string literals so the \`/candles/graphql\` proxy regex chain-prefixes them

**\`src/hooks/usePoolData.js\`** (volume / liquidity)
- Replaced \`proposal { currencyToken { symbol } pools { token0 { … } } }\` with a single batched flat query for \`proposal + whitelistedtokens + pools\`
- Built an address → {symbol, decimals, role} map from \`whitelistedtokens\` and enrich each pool's flat \`token0\`/\`token1\` address strings into Graph-Node-shaped objects, so the existing \`formatSubgraphPoolData\` keeps working unchanged
- Divide \`volumeToken0/1\` by \`10^decimals\` (Checkpoint stores raw wei; previous code assumed already-human numbers)

## Test plan
- [ ] After deploy, visit https://futarchy.fi/markets/0x1a0f209fa9730a4668ce43ce18982cb0010a972a
- [ ] Chart panel renders YES/NO candle lines, no 502 banner
- [ ] Stat row shows non-zero Volume (~7.7K sDAI total) and non-zero Liquidity
- [ ] YES/NO prices populate (~111.21 / ~107.37)
- [ ] Spot price still shows ~107.83 sDAI (already worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)