### PR TITLE
fix(proposals): honor visibility=hidden on the milestones list page

### DIFF
--- a/src/components/futarchyFi/proposalsList/cards/ProposalsCard.jsx
+++ b/src/components/futarchyFi/proposalsList/cards/ProposalsCard.jsx
@@ -381,6 +381,8 @@ export const ProposalsCard = ({
   poolAddresses,
   metadata,
   resolutionStatus,
+  visibility = 'public',
+  isOwner = false,
 }) => {
   // ✅ REFACTORED: Determine the appropriate image based on metadata
   const getProposalImage = () => {
@@ -501,7 +503,20 @@ export const ProposalsCard = ({
                   endTime={endTime}
                   resolutionStatus={resolutionStatus}
                 />
-                <ProposalStatus approvalStatus={approvalStatus} />
+                <div className="flex items-center gap-2">
+                  {visibility === 'hidden' && isOwner && (
+                    <span
+                      className="px-2 py-1 rounded-lg text-xs font-medium bg-gray-500/20 text-gray-400 border border-gray-500/30 flex items-center gap-1"
+                      title="This proposal is hidden from the public. Only visible to you as owner."
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                      </svg>
+                      Hidden
+                    </span>
+                  )}
+                  <ProposalStatus approvalStatus={approvalStatus} />
+                </div>
               </div>
               <div className="flex flex-col p-3 gap-3">
                 {/* Title with data-testid - Larger and more lines */}
@@ -588,6 +603,8 @@ export const MobileProposalsCard = ({
   poolAddresses,
   metadata,
   resolutionStatus,
+  visibility = 'public',
+  isOwner = false,
 }) => {
   // ✅ REFACTORED: Determine the appropriate image based on metadata
   const getProposalImage = () => {
@@ -701,7 +718,20 @@ export const MobileProposalsCard = ({
                   resolutionStatus={resolutionStatus}
                 />
               </div>
-              <ProposalStatus approvalStatus={approvalStatus} />
+              <div className="flex items-center gap-2">
+                {visibility === 'hidden' && isOwner && (
+                  <span
+                    className="px-2 py-1 rounded-lg text-xs font-medium bg-gray-500/20 text-gray-400 border border-gray-500/30 flex items-center gap-1"
+                    title="This proposal is hidden from the public. Only visible to you as owner."
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                    Hidden
+                  </span>
+                )}
+                <ProposalStatus approvalStatus={approvalStatus} />
+              </div>
             </div>
 
             {/* Title - Larger and more lines for mobile */}

--- a/src/components/futarchyFi/proposalsList/page/proposalsPage/ProposalsPage.jsx
+++ b/src/components/futarchyFi/proposalsList/page/proposalsPage/ProposalsPage.jsx
@@ -183,6 +183,11 @@ const ProposalsPage = ({
                 : 'ongoing',
               resolution_status: proposalMeta.resolution_status || null,
               resolution_outcome: proposalMeta.resolution_outcome || null,
+              // Visibility: 'public' (default) or 'hidden'. Hidden proposals are
+              // filtered from the public list below and shown to the org owner
+              // with a "Hidden" badge (mirrors EventHighlightCard's convention).
+              visibility: proposalMeta.visibility || 'public',
+              isOwner,
               chainId,
               // Use org's cover image as the card banner
               image: subgraphOrg.coverImage || subgraphOrg.logo || PROPOSAL_IMAGES['gnosis-pay'],
@@ -232,9 +237,22 @@ const ProposalsPage = ({
   ];
 
   // Update the filter logic to handle new options and debug mode
+  // Hidden proposals are removed from the public list, but still shown to the
+  // org owner (who sees a "Hidden" badge on the card). Matches the convention
+  // used by EventHighlightCard / the company carousels. Without this, hidden
+  // proposals leaked onto the milestones list (this page reads the raw,
+  // unfiltered org.proposals from useOrganization, which does no filtering).
+  const isVisibleToViewer = (proposal) =>
+    !(proposal.visibility === "hidden" && !isOwner && !debugMode);
+
   const filteredProposals = (proposals || []).filter((proposal) => {
     // First apply debug mode filtering - hide pending_review unless debug mode is on
     if (proposal.approvalStatus === "pending_review" && !debugMode) {
+      return false;
+    }
+
+    // Visibility: drop 'hidden' proposals for the public (owner/debug still see them)
+    if (!isVisibleToViewer(proposal)) {
       return false;
     }
 
@@ -262,9 +280,10 @@ const ProposalsPage = ({
   // Calculate active proposals count
   const activeProposalsCount = useMemo(() => {
     return proposals.filter((proposal) =>
-      proposal.approvalStatus === "ongoing" || proposal.approvalStatus === "on_going"
+      isVisibleToViewer(proposal) &&
+      (proposal.approvalStatus === "ongoing" || proposal.approvalStatus === "on_going")
     ).length;
-  }, [proposals]);
+  }, [proposals, isOwner, debugMode]);
 
   // Calculate total visible milestones count (respecting debug mode)
   const visibleMilestonesCount = useMemo(() => {
@@ -273,9 +292,13 @@ const ProposalsPage = ({
       if (proposal.approvalStatus === "pending_review" && !debugMode) {
         return false;
       }
+      // Hide 'hidden' proposals from non-owners
+      if (!isVisibleToViewer(proposal)) {
+        return false;
+      }
       return true;
     }).length;
-  }, [proposals, debugMode]);
+  }, [proposals, debugMode, isOwner]);
 
   const heroContent = useMemo(() => {
     if (isLoadingCompany) {


### PR DESCRIPTION
## Problem

A proposal marked `visibility: "hidden"` in its on-chain metadata (e.g. GIP-150 `0x1a0f209…972a`) **still appeared to everyone** on the `/<org>/milestones` list page — even though the homepage highlight cards and company carousels already hide it.

Root cause: `ProposalsPage` reads the **raw, unfiltered** `org.proposals` from `useOrganization` (which does no visibility filtering), and **neither** the page's `filteredProposals` **nor** `ProposalsCard` did anything with the `visibility` flag. So this surface ignored hidden entirely.

(`EventHighlightCard` and `useAggregatorCompanies` already implement this correctly — this PR brings `ProposalsPage`/`ProposalsCard` in line.)

## Fix — mirror the existing `EventHighlightCard` convention

- **ProposalsPage**: thread `visibility` (default `'public'`) + `isOwner` onto each transformed proposal object; filter `visibility==='hidden'` out of the public list and the active/total counts. The org **owner** (and `?debugMode=true`) still see hidden proposals.
- **ProposalsCard + MobileProposalsCard**: render the same **"Hidden" eye-badge** shown to the owner (identical icon/markup to `EventHighlightCard`), next to the status pill.

## Result
- Public: hidden proposals drop off the milestones list (and counts).
- Owner: still sees them, now clearly flagged **Hidden** instead of silently listed.

## Safety
- Additive, backward-compatible: `visibility` defaults to `'public'` when the flag is absent, so existing proposals are unaffected.
- Cards receive props via the existing `{...proposal}` spread; new props default to safe values (`'public'` / `false`).
- No data/query changes.

## Verification
- Confirmed on-chain + registry that GIP-150 is `visibility:"hidden"`, and that GIP-149's hidden dupes already render the badge via `EventHighlightCard` (the pattern copied here).
- Brace/paren balance checked on both files; only pre-existing unused-import lint warnings remain (untouched).
- Not run: full `next build` / browser check — recommend a reviewer load the milestones page connected as non-owner (GIP-150 absent) vs owner (GIP-150 shows "Hidden" badge).