### PR TITLE
[codex] add ops signer for GIP-151

### DIFF
--- a/docs/OPS_SIGNER_PLAN.md
+++ b/docs/OPS_SIGNER_PLAN.md
@@ -1,0 +1,180 @@
+# Ops Signer Plan
+
+## Goal
+
+Build a small `/ops` page inside `futarchy.fi` where an authorized wallet, starting with `0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649`, can connect with Rabby or another injected wallet and sign narrowly scoped administrative transactions.
+
+The first target action is linking the GIP-151 Snapshot proposal to its Futarchy market through `SnapshotLinkRegistry.upsert(bytes32 snapshotId, uint256 futarchyId)`.
+
+## Product Shape
+
+The page should be an intent signer, not a raw transaction builder.
+
+Each pending action is a typed, repo-backed manifest. The UI renders the human-readable intent, shows the exact contract/function/arguments, runs prechecks, simulates the transaction when possible, and only enables signing when the connected wallet and chain are correct.
+
+The page must never accept arbitrary calldata from query params, a mutable database row, or free-form user input.
+
+## Initial Route
+
+- Add `src/pages/ops/index.jsx`.
+- Add `netlify/edge-functions/ops-access.js`.
+- Use the existing app providers: Next.js, Wagmi, RainbowKit, viem, and the configured Gnosis Chain transport.
+- Rabby should work as an injected wallet through RainbowKit/Wagmi.
+- Require Gnosis Chain (`chainId: 100`) for the initial action set.
+- Do not link this route from regular app navigation.
+- Protect the route at the Netlify edge because the app is statically exported.
+
+## Repository Layout
+
+Suggested files:
+
+- `src/ops/abis/snapshotLinkRegistry.js`
+- `src/ops/actions/gip151.js`
+- `src/ops/actions/index.js`
+- `src/ops/actionTypes/snapshotLinkUpsert.js`
+- `src/ops/components/OpsActionCard.jsx`
+- `src/pages/ops/index.jsx`
+- `netlify/edge-functions/ops-access.js`
+
+Keep action builders and validation logic in the repo. Keep active action manifests in the repo for v0.
+
+## Action Manifest Model
+
+Each action should define:
+
+- `id`
+- `title`
+- `description`
+- `chainId`
+- `requiredSigner`
+- `target`
+- `abi`
+- `functionName`
+- `args`
+- `prechecks`
+- `postcheck`
+- `explorerLinks`
+
+Example:
+
+```js
+export const gip151SnapshotLinkAction = {
+  id: 'gip151-snapshot-link',
+  title: 'Link GIP-151 Snapshot widget',
+  chainId: 100,
+  requiredSigner: '0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649',
+  target: '0xa6Bc2857906C808bc0041f3A2977F53c6b6b0823',
+  functionName: 'upsert',
+  args: [
+    '0x657fbf8892200d24e887c68245cee73b59c466394192be1c10673b39814c74c4',
+    435
+  ],
+  postcheck: {
+    functionName: 'getFutarchyId',
+    args: ['0x657fbf8892200d24e887c68245cee73b59c466394192be1c10673b39814c74c4'],
+    expect: { id: 435, exists: true }
+  }
+};
+```
+
+The page should compute "pending" from chain state. An action is pending when its postcheck is false.
+
+## GIP-151 Constants
+
+- Snapshot proposal: `GIP-151: Should GnosisDAO offer a one-time pro-rata treasury redemption?`
+- Snapshot id: `0x657fbf8892200d24e887c68245cee73b59c466394192be1c10673b39814c74c4`
+- Snapshot space: `gnosis.eth`
+- SnapshotLinkRegistry: `0xa6Bc2857906C808bc0041f3A2977F53c6b6b0823`
+- SnapshotLinkRegistry owner: `0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649`
+- Expected FutarchyFactory id after the next market creation: `435`
+- FutarchyFactory: `0xa6cB18FCDC17a2B44E5cAd2d80a6D5942d30a345`
+- Expected GIP-151 market address from dry-run before sending: `0xeCe80208CB8376Be311cE0f5Ea4eF73850a0dcF0`
+
+Before enabling the GIP-151 action, verify that `FutarchyFactory.proposals(435)` equals the actual created GIP-151 market address. If market creation changes the factory index, update the manifest before deployment.
+
+## UI Requirements
+
+The `/ops` page should show:
+
+- Connected wallet address, unshortened or with an easy full-copy affordance.
+- Current chain and required chain.
+- Required signer for each action.
+- Current postcheck status.
+- Target contract, function name, decoded arguments, and Gnosisscan links.
+- Simulation status where viem can simulate the write.
+- A single "Sign transaction" button per action.
+- Transaction hash, receipt status, and postcheck status after signing.
+
+Disable signing when:
+
+- Wallet is disconnected.
+- Chain is not Gnosis.
+- Connected wallet is not the required signer.
+- Postcheck already passes.
+- Precheck fails.
+- Simulation fails.
+
+## Safety Requirements
+
+- No arbitrary calldata.
+- No query-param controlled targets, ABIs, functions, or args.
+- No backend signing.
+- No private keys in the app.
+- No hidden action execution on load.
+- Require a direct click for every wallet signature.
+- Show exact function and args before signing.
+- Use postchecks to make completed actions disappear or show as complete.
+
+Optional hardening:
+
+- Put `/ops` behind Cloudflare Access.
+- Add an action checksum to the UI for copy-review.
+- Add a manual "I reviewed this transaction" checkbox for owner-only actions.
+
+## Access Gate
+
+The page should be hidden from regular app flow and regular URL access. Because `futarchy.fi` is built as a static
+Next export, this gate lives in a Netlify Edge Function rather than `getServerSideProps`.
+
+Production behavior:
+
+- `OPS_SIGNER_ACCESS_KEY` must be set in the deployment environment.
+- `/ops` without access returns 404.
+- `/ops?access=<OPS_SIGNER_ACCESS_KEY>` sets an HttpOnly, Secure, SameSite=Strict, HMAC-signed cookie scoped to `/ops`, then redirects to `/ops`.
+- The cookie is checked by the Netlify Edge Function on later visits.
+- The access key is not embedded into the client bundle.
+- The page remains unlinked from normal navigation and is marked `noindex,nofollow`.
+
+Development behavior:
+
+- `next dev` serves the static page directly for local UI work.
+- `netlify dev` can test the access gate when `OPS_SIGNER_ACCESS_KEY` is set.
+
+## First Implementation Steps
+
+1. Add the SnapshotLinkRegistry ABI with `owner`, `getFutarchyId`, and `upsert`.
+2. Add a typed `snapshotLinkUpsert` action builder.
+3. Add the GIP-151 action manifest.
+4. Build `/ops` around the existing Wagmi/RainbowKit providers.
+5. Use `useAccount`, `useChainId`, `useSwitchChain`, `usePublicClient`, and `useWriteContract`.
+6. Read `owner()` and `getFutarchyId(snapshotId)`.
+7. Simulate `upsert(snapshotId, futarchyId)` when the connected wallet is the required signer.
+8. Send the transaction through the connected wallet.
+9. Wait for receipt and rerun postcheck.
+10. Verify with a local Next.js build and browser smoke test.
+
+## Acceptance Criteria
+
+- `/ops` loads inside the existing app shell.
+- Connecting Rabby as `0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649` on Gnosis enables the GIP-151 Snapshot link action when the registry mapping is missing.
+- Connecting any other wallet shows the action read-only and disabled.
+- The page displays the exact `upsert` target, function, and args before signing.
+- After signing, the page shows the tx hash and confirms `getFutarchyId(snapshotId) -> (435, true)`.
+- If the mapping already exists, the action is marked complete and cannot be signed again.
+- There is no free-form calldata path.
+
+## Proposed `/goal` Command
+
+```text
+/goal Build and deploy a repo-backed `/ops` signer page in the futarchy.fi interface that lets the authorized wallet `0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649` connect with Rabby on Gnosis Chain and sign typed, prechecked administrative actions. Implement the first action for GIP-151 Snapshot widget linking via `SnapshotLinkRegistry.upsert(0x657fbf8892200d24e887c68245cee73b59c466394192be1c10673b39814c74c4, 435)`, with owner/wallet/chain checks, explicit decoded transaction review, simulation where possible, receipt tracking, and postcheck confirmation through `getFutarchyId`. Keep allowed action builders and active action manifests in the repo, reject arbitrary calldata, run build/browser verification, and leave a concise handoff with file paths, verification results, and any deployment or signing steps still requiring the owner wallet.
+```

--- a/netlify/edge-functions/ops-access.js
+++ b/netlify/edge-functions/ops-access.js
@@ -1,0 +1,131 @@
+const ACCESS_KEY_ENV = 'OPS_SIGNER_ACCESS_KEY';
+const ACCESS_QUERY_PARAM = 'access';
+const COOKIE_NAME = 'futarchy_ops_access';
+const COOKIE_TTL_SECONDS = 24 * 60 * 60;
+const COOKIE_VERSION = 'v1';
+
+function getEnv(name) {
+  if (globalThis.Netlify?.env?.get) {
+    return globalThis.Netlify.env.get(name);
+  }
+
+  if (typeof Deno !== 'undefined' && Deno.env?.get) {
+    return Deno.env.get(name);
+  }
+
+  return undefined;
+}
+
+function notFound() {
+  return new Response('Not found', {
+    status: 404,
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'text/plain; charset=utf-8',
+      'x-robots-tag': 'noindex, nofollow',
+    },
+  });
+}
+
+function timingSafeEqual(left = '', right = '') {
+  const leftBytes = new TextEncoder().encode(left);
+  const rightBytes = new TextEncoder().encode(right);
+  const length = Math.max(leftBytes.length, rightBytes.length);
+  let diff = leftBytes.length ^ rightBytes.length;
+
+  for (let index = 0; index < length; index += 1) {
+    diff |= (leftBytes[index] || 0) ^ (rightBytes[index] || 0);
+  }
+
+  return diff === 0;
+}
+
+function base64Url(bytes) {
+  let value = '';
+  bytes.forEach((byte) => {
+    value += String.fromCharCode(byte);
+  });
+
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+async function signToken(secret, expiresAt) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(`ops:${expiresAt}`));
+
+  return base64Url(new Uint8Array(signature));
+}
+
+async function createCookieToken(secret) {
+  const expiresAt = Date.now() + COOKIE_TTL_SECONDS * 1000;
+  const signature = await signToken(secret, expiresAt);
+
+  return `${COOKIE_VERSION}.${expiresAt}.${signature}`;
+}
+
+async function isCookieTokenValid(token, secret) {
+  const [version, expiresAt, signature] = String(token || '').split('.');
+  const expiresAtNumber = Number(expiresAt);
+
+  if (version !== COOKIE_VERSION || !Number.isFinite(expiresAtNumber) || expiresAtNumber <= Date.now()) {
+    return false;
+  }
+
+  const expectedSignature = await signToken(secret, expiresAt);
+
+  return timingSafeEqual(signature, expectedSignature);
+}
+
+function setAccessCookieResponse(url, token) {
+  const redirectUrl = new URL('/ops', url);
+  const isLocalhost = redirectUrl.hostname === 'localhost' || redirectUrl.hostname === '127.0.0.1';
+  const secureAttribute = isLocalhost ? '' : '; Secure';
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'cache-control': 'no-store',
+      location: redirectUrl.pathname,
+      'set-cookie': `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/ops; Max-Age=${COOKIE_TTL_SECONDS}; HttpOnly${secureAttribute}; SameSite=Strict`,
+      'x-robots-tag': 'noindex, nofollow',
+    },
+  });
+}
+
+export default async function opsAccess(request, context) {
+  const accessKey = getEnv(ACCESS_KEY_ENV);
+
+  if (!accessKey) {
+    return notFound();
+  }
+
+  const url = new URL(request.url);
+  const queryAccess = url.searchParams.get(ACCESS_QUERY_PARAM);
+
+  if (queryAccess && timingSafeEqual(queryAccess, accessKey)) {
+    const token = await createCookieToken(accessKey);
+
+    return setAccessCookieResponse(url, token);
+  }
+
+  if (await isCookieTokenValid(context.cookies.get(COOKIE_NAME), accessKey)) {
+    const response = await context.next();
+    response.headers.set('x-robots-tag', 'noindex, nofollow');
+    response.headers.set('cache-control', 'no-store');
+
+    return response;
+  }
+
+  return notFound();
+}
+
+export const config = {
+  path: ['/ops', '/ops/', '/ops.html', '/ops/index.html'],
+};

--- a/src/ops/abis/futarchyFactory.js
+++ b/src/ops/abis/futarchyFactory.js
@@ -1,0 +1,16 @@
+export const futarchyFactoryAbi = [
+  {
+    inputs: [],
+    name: 'marketsCount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'proposals',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/src/ops/abis/snapshotLinkRegistry.js
+++ b/src/ops/abis/snapshotLinkRegistry.js
@@ -1,0 +1,29 @@
+export const snapshotLinkRegistryAbi = [
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes32', name: 'snapshotId', type: 'bytes32' }],
+    name: 'getFutarchyId',
+    outputs: [
+      { internalType: 'uint256', name: 'id', type: 'uint256' },
+      { internalType: 'bool', name: 'exists', type: 'bool' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'bytes32', name: 'snapshotId', type: 'bytes32' },
+      { internalType: 'uint256', name: 'futarchyId', type: 'uint256' },
+    ],
+    name: 'upsert',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/src/ops/actionTypes/snapshotLinkUpsert.js
+++ b/src/ops/actionTypes/snapshotLinkUpsert.js
@@ -1,0 +1,94 @@
+import { futarchyFactoryAbi } from '../abis/futarchyFactory';
+import { snapshotLinkRegistryAbi } from '../abis/snapshotLinkRegistry';
+
+export const GNOSIS_CHAIN_ID = 100;
+
+export const FUTARCHY_FACTORY_ADDRESS = '0xa6cB18FCDC17a2B44E5cAd2d80a6D5942d30a345';
+export const SNAPSHOT_LINK_REGISTRY_ADDRESS = '0xa6Bc2857906C808bc0041f3A2977F53c6b6b0823';
+export const SNAPSHOT_LINK_REGISTRY_OWNER = '0xEB2AEC308e7B3340Dea2E89d40187D2637C6c649';
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const BYTES32_RE = /^0x[a-fA-F0-9]{64}$/;
+
+function requireAddress(value, label) {
+  if (!ADDRESS_RE.test(value || '')) {
+    throw new Error(`${label} must be an EVM address`);
+  }
+  return value;
+}
+
+function requireBytes32(value, label) {
+  if (!BYTES32_RE.test(value || '')) {
+    throw new Error(`${label} must be a bytes32 value`);
+  }
+  return value;
+}
+
+function requireWholeNumber(value, label) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+export function buildSnapshotLinkUpsertAction({
+  id,
+  title,
+  description,
+  snapshotId,
+  futarchyId,
+  expectedMarketAddress,
+  requiredSigner = SNAPSHOT_LINK_REGISTRY_OWNER,
+}) {
+  requireBytes32(snapshotId, 'snapshotId');
+  requireWholeNumber(futarchyId, 'futarchyId');
+  requireAddress(expectedMarketAddress, 'expectedMarketAddress');
+  requireAddress(requiredSigner, 'requiredSigner');
+
+  return {
+    id,
+    type: 'snapshotLinkRegistry.upsert',
+    title,
+    description,
+    chainId: GNOSIS_CHAIN_ID,
+    chainName: 'Gnosis Chain',
+    requiredSigner,
+    target: SNAPSHOT_LINK_REGISTRY_ADDRESS,
+    targetLabel: 'SnapshotLinkRegistry',
+    abi: snapshotLinkRegistryAbi,
+    functionName: 'upsert',
+    args: [snapshotId, BigInt(futarchyId)],
+    displayArgs: [
+      { label: 'snapshotId', value: snapshotId },
+      { label: 'futarchyId', value: String(futarchyId) },
+    ],
+    explorerLinks: {
+      target: `https://gnosisscan.io/address/${SNAPSHOT_LINK_REGISTRY_ADDRESS}`,
+      requiredSigner: `https://gnosisscan.io/address/${requiredSigner}`,
+      market: `https://gnosisscan.io/address/${expectedMarketAddress}`,
+    },
+    reads: {
+      registryOwner: {
+        address: SNAPSHOT_LINK_REGISTRY_ADDRESS,
+        abi: snapshotLinkRegistryAbi,
+        functionName: 'owner',
+        expected: requiredSigner,
+      },
+      factoryProposal: {
+        address: FUTARCHY_FACTORY_ADDRESS,
+        abi: futarchyFactoryAbi,
+        countFunctionName: 'marketsCount',
+        functionName: 'proposals',
+        args: [BigInt(futarchyId)],
+        expected: expectedMarketAddress,
+      },
+      postcheck: {
+        address: SNAPSHOT_LINK_REGISTRY_ADDRESS,
+        abi: snapshotLinkRegistryAbi,
+        functionName: 'getFutarchyId',
+        args: [snapshotId],
+        expected: { id: BigInt(futarchyId), exists: true },
+      },
+    },
+  };
+}

--- a/src/ops/actions/gip151.js
+++ b/src/ops/actions/gip151.js
@@ -1,0 +1,11 @@
+import { buildSnapshotLinkUpsertAction } from '../actionTypes/snapshotLinkUpsert';
+
+export const gip151SnapshotLinkAction = buildSnapshotLinkUpsertAction({
+  id: 'gip151-snapshot-link',
+  title: 'Link GIP-151 Snapshot widget',
+  description:
+    'Registers the GIP-151 Snapshot proposal hash against its FutarchyFactory id so the Snapshot widget can resolve the market.',
+  snapshotId: '0x657fbf8892200d24e887c68245cee73b59c466394192be1c10673b39814c74c4',
+  futarchyId: 435,
+  expectedMarketAddress: '0xeCe80208CB8376Be311cE0f5Ea4eF73850a0dcF0',
+});

--- a/src/ops/actions/index.js
+++ b/src/ops/actions/index.js
@@ -1,0 +1,3 @@
+import { gip151SnapshotLinkAction } from './gip151';
+
+export const opsActions = [gip151SnapshotLinkAction];

--- a/src/ops/components/OpsActionCard.jsx
+++ b/src/ops/components/OpsActionCard.jsx
@@ -1,0 +1,407 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useAccount,
+  useChainId,
+  usePublicClient,
+  useSwitchChain,
+  useWaitForTransactionReceipt,
+  useWriteContract,
+} from 'wagmi';
+import { addressesEqual, formatValue, getErrorMessage, shortAddress } from '../utils';
+
+function StatusPill({ tone = 'neutral', children }) {
+  const classes = {
+    neutral: 'border-futarchyGray5 bg-white text-futarchyGray11',
+    success: 'border-futarchyGreen6 bg-futarchyGreen3 text-futarchyGreen11',
+    warning: 'border-warning/50 bg-warning/10 text-darkWarning',
+    error: 'border-danger/40 bg-danger/10 text-danger',
+  };
+
+  return (
+    <span className={`inline-flex h-7 items-center rounded-md border px-2.5 text-xs font-semibold ${classes[tone]}`}>
+      {children}
+    </span>
+  );
+}
+
+function DetailRow({ label, value, href }) {
+  const content = (
+    <code className="block max-w-full break-all rounded bg-futarchyGray2 px-2 py-1 font-mono text-xs text-futarchyGray12">
+      {value}
+    </code>
+  );
+
+  return (
+    <div className="grid min-w-0 gap-2 border-b border-futarchyGray4 py-3 last:border-b-0 md:grid-cols-[160px_minmax(0,1fr)]">
+      <div className="text-xs font-semibold uppercase tracking-wide text-futarchyGray11">{label}</div>
+      <div className="min-w-0">
+        {href ? (
+          <a href={href} target="_blank" rel="noreferrer" className="block min-w-0 hover:underline">
+            {content}
+          </a>
+        ) : (
+          content
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CheckRow({ label, state, detail }) {
+  const tone = state === 'pass' ? 'success' : state === 'fail' ? 'error' : 'warning';
+  const text = state === 'pass' ? 'Pass' : state === 'fail' ? 'Fail' : 'Pending';
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2 rounded-md border border-futarchyGray4 bg-white p-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0">
+        <div className="text-sm font-semibold text-futarchyGray12">{label}</div>
+        {detail && <div className="mt-1 break-words text-xs text-futarchyGray11">{detail}</div>}
+      </div>
+      <StatusPill tone={tone}>{text}</StatusPill>
+    </div>
+  );
+}
+
+export default function OpsActionCard({ action }) {
+  const { address, isConnected } = useAccount();
+  const chainId = useChainId();
+  const publicClient = usePublicClient({ chainId: action.chainId });
+  const { switchChainAsync, isPending: isSwitching } = useSwitchChain();
+  const { writeContract, data: hash, error: writeError, isPending: isWritePending } = useWriteContract();
+  const { isLoading: isReceiptLoading, isSuccess: isReceiptSuccess } = useWaitForTransactionReceipt({
+    hash,
+    chainId: action.chainId,
+  });
+
+  const [checks, setChecks] = useState({
+    loading: true,
+    registryOwner: null,
+    factoryProposal: null,
+    postcheck: null,
+    error: null,
+  });
+  const [simulation, setSimulation] = useState({ status: 'idle', error: null });
+
+  const connectedSignerOk = useMemo(
+    () => addressesEqual(address, action.requiredSigner),
+    [address, action.requiredSigner]
+  );
+  const chainOk = chainId === action.chainId;
+
+  const loadChecks = useCallback(async () => {
+    if (!publicClient) return;
+
+    setChecks((current) => ({ ...current, loading: true, error: null }));
+
+    try {
+      const owner = await publicClient.readContract({
+        address: action.reads.registryOwner.address,
+        abi: action.reads.registryOwner.abi,
+        functionName: action.reads.registryOwner.functionName,
+      });
+
+      const marketsCount = await publicClient.readContract({
+        address: action.reads.factoryProposal.address,
+        abi: action.reads.factoryProposal.abi,
+        functionName: action.reads.factoryProposal.countFunctionName,
+      });
+
+      let proposalAddress = null;
+      let proposalError = null;
+      if (BigInt(marketsCount) > action.reads.factoryProposal.args[0]) {
+        try {
+          proposalAddress = await publicClient.readContract({
+            address: action.reads.factoryProposal.address,
+            abi: action.reads.factoryProposal.abi,
+            functionName: action.reads.factoryProposal.functionName,
+            args: action.reads.factoryProposal.args,
+          });
+        } catch (error) {
+          proposalError = getErrorMessage(error);
+        }
+      }
+
+      const postcheckResult = await publicClient.readContract({
+        address: action.reads.postcheck.address,
+        abi: action.reads.postcheck.abi,
+        functionName: action.reads.postcheck.functionName,
+        args: action.reads.postcheck.args,
+      });
+      const [linkedId, linkedExists] = postcheckResult;
+
+      setChecks({
+        loading: false,
+        registryOwner: {
+          value: owner,
+          pass: addressesEqual(owner, action.reads.registryOwner.expected),
+        },
+        factoryProposal: {
+          marketsCount,
+          value: proposalAddress,
+          error: proposalError,
+          pass: addressesEqual(proposalAddress, action.reads.factoryProposal.expected),
+        },
+        postcheck: {
+          id: linkedId,
+          exists: linkedExists,
+          pass: Boolean(linkedExists && BigInt(linkedId) === action.reads.postcheck.expected.id),
+        },
+        error: null,
+      });
+    } catch (error) {
+      setChecks({
+        loading: false,
+        registryOwner: null,
+        factoryProposal: null,
+        postcheck: null,
+        error: getErrorMessage(error),
+      });
+    }
+  }, [action, publicClient]);
+
+  useEffect(() => {
+    loadChecks();
+  }, [loadChecks, isReceiptSuccess]);
+
+  const prechecksPass = Boolean(checks.registryOwner?.pass && checks.factoryProposal?.pass);
+  const actionComplete = Boolean(checks.postcheck?.pass);
+  const canSimulate = Boolean(isConnected && connectedSignerOk && chainOk && prechecksPass && !actionComplete && publicClient);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function simulate() {
+      if (!canSimulate) {
+        setSimulation({ status: 'idle', error: null });
+        return;
+      }
+
+      setSimulation({ status: 'loading', error: null });
+      try {
+        await publicClient.simulateContract({
+          address: action.target,
+          abi: action.abi,
+          functionName: action.functionName,
+          args: action.args,
+          account: address,
+        });
+        if (!cancelled) setSimulation({ status: 'success', error: null });
+      } catch (error) {
+        if (!cancelled) setSimulation({ status: 'error', error: getErrorMessage(error) });
+      }
+    }
+
+    simulate();
+    return () => {
+      cancelled = true;
+    };
+  }, [action, address, canSimulate, publicClient]);
+
+  const disabledReason = useMemo(() => {
+    if (actionComplete) return 'Action already complete';
+    if (!isConnected) return 'Connect wallet';
+    if (!chainOk) return 'Switch to Gnosis Chain';
+    if (!connectedSignerOk) return 'Connected wallet is not the required signer';
+    if (checks.loading) return 'Loading checks';
+    if (checks.error) return 'Checks failed';
+    if (!prechecksPass) return 'Prechecks must pass';
+    if (simulation.status === 'loading') return 'Simulating transaction';
+    if (simulation.status !== 'success') return 'Simulation must pass';
+    return '';
+  }, [
+    actionComplete,
+    chainOk,
+    checks.error,
+    checks.loading,
+    connectedSignerOk,
+    isConnected,
+    prechecksPass,
+    simulation.status,
+  ]);
+
+  const handleSwitchChain = async () => {
+    await switchChainAsync({ chainId: action.chainId });
+  };
+
+  const handleSign = () => {
+    writeContract({
+      address: action.target,
+      abi: action.abi,
+      functionName: action.functionName,
+      args: action.args,
+      chainId: action.chainId,
+    });
+  };
+
+  return (
+    <section data-ops-action-card className="min-w-0 rounded-lg border border-futarchyGray5 bg-futarchyGray1 shadow-sm">
+      <div className="border-b border-futarchyGray4 p-5">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <div className="mb-2 flex flex-wrap gap-2">
+              <StatusPill tone={actionComplete ? 'success' : 'warning'}>
+                {actionComplete ? 'Complete' : 'Pending'}
+              </StatusPill>
+              <StatusPill tone={chainOk ? 'success' : 'error'}>{action.chainName}</StatusPill>
+              <StatusPill tone={connectedSignerOk ? 'success' : isConnected ? 'error' : 'neutral'}>
+                {isConnected ? shortAddress(address) : 'No wallet'}
+              </StatusPill>
+            </div>
+            <h2 className="text-xl font-semibold text-futarchyGray12">{action.title}</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-futarchyGray11">{action.description}</p>
+          </div>
+          <button
+            type="button"
+            onClick={loadChecks}
+            className="h-10 rounded-md border border-futarchyGray5 px-4 text-sm font-semibold text-futarchyGray12 transition hover:bg-white"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid min-w-0 gap-5 p-5 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <div className="min-w-0 space-y-5">
+          <div className="min-w-0 rounded-lg border border-futarchyGray4 bg-white p-4">
+            <h3 className="text-sm font-semibold text-futarchyGray12">Transaction</h3>
+            <div className="mt-3">
+              <DetailRow label="Contract" value={`${action.targetLabel} ${action.target}`} href={action.explorerLinks.target} />
+              <DetailRow label="Function" value={action.functionName} />
+              {action.displayArgs.map((arg) => (
+                <DetailRow key={arg.label} label={arg.label} value={arg.value} />
+              ))}
+              <DetailRow label="Required signer" value={action.requiredSigner} href={action.explorerLinks.requiredSigner} />
+            </div>
+          </div>
+
+          <div className="min-w-0 rounded-lg border border-futarchyGray4 bg-white p-4">
+            <h3 className="text-sm font-semibold text-futarchyGray12">Checks</h3>
+            <div className="mt-3 space-y-3">
+              <CheckRow
+                label="Registry owner"
+                state={checks.registryOwner?.pass ? 'pass' : checks.registryOwner ? 'fail' : 'pending'}
+                detail={
+                  checks.registryOwner
+                    ? `owner() = ${checks.registryOwner.value}`
+                    : 'Reads SnapshotLinkRegistry.owner()'
+                }
+              />
+              <CheckRow
+                label="Factory id points to expected market"
+                state={checks.factoryProposal?.pass ? 'pass' : checks.factoryProposal ? 'fail' : 'pending'}
+                detail={
+                  checks.factoryProposal
+                    ? checks.factoryProposal.value
+                      ? `proposals(${formatValue(action.reads.factoryProposal.args[0])}) = ${checks.factoryProposal.value}`
+                      : `marketsCount() = ${formatValue(checks.factoryProposal.marketsCount)}; expected id is not available yet`
+                    : 'Verifies the FutarchyFactory id before enabling signing'
+                }
+              />
+              <CheckRow
+                label="Snapshot link postcheck"
+                state={checks.postcheck?.pass ? 'pass' : checks.postcheck ? 'fail' : 'pending'}
+                detail={
+                  checks.postcheck
+                    ? `getFutarchyId(snapshotId) = (${formatValue(checks.postcheck.id)}, ${formatValue(checks.postcheck.exists)})`
+                    : 'Reads the current SnapshotLinkRegistry mapping'
+                }
+              />
+              <CheckRow
+                label="Simulation"
+                state={
+                  simulation.status === 'success'
+                    ? 'pass'
+                    : simulation.status === 'error'
+                      ? 'fail'
+                      : 'pending'
+                }
+                detail={
+                  simulation.status === 'success'
+                    ? 'Transaction simulation passed for the connected signer'
+                    : simulation.error || 'Simulation runs only after wallet, chain, and prechecks pass'
+                }
+              />
+            </div>
+            {checks.error && (
+              <div className="mt-3 rounded-md border border-danger/40 bg-danger/10 p-3 text-sm text-danger">
+                {checks.error}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="min-w-0 space-y-5">
+          <div className="min-w-0 rounded-lg border border-futarchyGray4 bg-white p-4">
+            <h3 className="text-sm font-semibold text-futarchyGray12">Signer</h3>
+            <div className="mt-3 space-y-3 text-sm text-futarchyGray11">
+              <div>
+                <div className="font-semibold text-futarchyGray12">Connected wallet</div>
+                <code className="mt-1 block break-all rounded bg-futarchyGray2 px-2 py-1 font-mono text-xs">
+                  {address || 'Not connected'}
+                </code>
+              </div>
+              <div>
+                <div className="font-semibold text-futarchyGray12">Required wallet</div>
+                <code className="mt-1 block break-all rounded bg-futarchyGray2 px-2 py-1 font-mono text-xs">
+                  {action.requiredSigner}
+                </code>
+              </div>
+            </div>
+          </div>
+
+          <div className="min-w-0 rounded-lg border border-futarchyGray4 bg-white p-4">
+            <h3 className="text-sm font-semibold text-futarchyGray12">Sign</h3>
+            <p className="mt-2 text-sm leading-6 text-futarchyGray11">
+              This button sends only the decoded transaction shown on this card. It does not build calldata from user input.
+            </p>
+            {!chainOk && isConnected ? (
+              <button
+                type="button"
+                onClick={handleSwitchChain}
+                disabled={isSwitching}
+                className="mt-4 h-11 w-full rounded-md bg-futarchyGray12 px-4 text-sm font-semibold text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSwitching ? 'Switching...' : 'Switch to Gnosis Chain'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSign}
+                disabled={Boolean(disabledReason) || isWritePending || isReceiptLoading}
+                className="mt-4 h-11 w-full rounded-md bg-futarchyGray12 px-4 text-sm font-semibold text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isWritePending || isReceiptLoading ? 'Waiting for wallet...' : 'Sign transaction'}
+              </button>
+            )}
+            {disabledReason && (
+              <div className="mt-3 rounded-md border border-futarchyGray4 bg-futarchyGray2 p-3 text-sm text-futarchyGray11">
+                {disabledReason}
+              </div>
+            )}
+            {writeError && (
+              <div className="mt-3 rounded-md border border-danger/40 bg-danger/10 p-3 text-sm text-danger">
+                {getErrorMessage(writeError)}
+              </div>
+            )}
+            {hash && (
+              <div className="mt-3 rounded-md border border-futarchyGreen6 bg-futarchyGreen3 p-3 text-sm text-futarchyGreen11">
+                <div className="font-semibold">Transaction submitted</div>
+                <a
+                  href={`https://gnosisscan.io/tx/${hash}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-1 block break-all font-mono text-xs underline"
+                >
+                  {hash}
+                </a>
+                <div className="mt-2 text-xs">
+                  {isReceiptSuccess ? 'Receipt confirmed. Postcheck refreshed.' : 'Waiting for receipt.'}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/ops/utils.js
+++ b/src/ops/utils.js
@@ -1,0 +1,21 @@
+export function addressesEqual(a, b) {
+  return Boolean(a && b && a.toLowerCase() === b.toLowerCase());
+}
+
+export function formatValue(value) {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) return `[${value.map(formatValue).join(', ')}]`;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+export function shortAddress(address) {
+  if (!address || address.length < 12) return address || '';
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function getErrorMessage(error) {
+  if (!error) return '';
+  return error.shortMessage || error.details || error.message || String(error);
+}

--- a/src/pages/ops/index.jsx
+++ b/src/pages/ops/index.jsx
@@ -1,0 +1,58 @@
+import Head from 'next/head';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import Header from '../../components/common/Header';
+import OpsActionCard from '../../ops/components/OpsActionCard';
+import { opsActions } from '../../ops/actions';
+
+export default function OpsPage() {
+  return (
+    <>
+      <Head>
+        <title>Ops Signer | Futarchy</title>
+        <meta
+          name="description"
+          content="Futarchy administrative signer for typed, prechecked owner actions."
+        />
+        <meta name="robots" content="noindex,nofollow" />
+      </Head>
+
+      <Header config="app" />
+
+      <main className="min-h-screen bg-futarchyGray2 px-4 pb-16 pt-28 text-futarchyGray12">
+        <div className="mx-auto max-w-6xl">
+          <section className="mb-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wide text-futarchyGray11">Futarchy ops</p>
+                <h1 className="mt-2 text-3xl font-semibold tracking-normal text-futarchyGray12 md:text-4xl">
+                  Typed action signer
+                </h1>
+                <p className="mt-3 max-w-3xl text-sm leading-6 text-futarchyGray11">
+                  Connect the authorized wallet and sign only repo-backed administrative actions. This page does not
+                  accept arbitrary calldata or mutable action definitions.
+                </p>
+              </div>
+              <div className="rounded-lg border border-futarchyGray5 bg-white p-3 shadow-sm">
+                <ConnectButton />
+              </div>
+            </div>
+          </section>
+
+          <section className="mb-6 rounded-lg border border-futarchyGray5 bg-white p-4 text-sm leading-6 text-futarchyGray11">
+            <div className="font-semibold text-futarchyGray12">Safety model</div>
+            <div className="mt-1">
+              Action types, ABIs, target contracts, arguments, required signers, prechecks, and postchecks are defined
+              in the repository. Signing is enabled only after wallet, chain, precheck, and simulation gates pass.
+            </div>
+          </section>
+
+          <div className="space-y-6">
+            {opsActions.map((action) => (
+              <OpsActionCard key={action.id} action={action} />
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/ops/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],


### PR DESCRIPTION
## Summary

Adds a repo-backed `/ops` signer page for typed Futarchy admin actions, initially scoped to linking the GIP-151 Snapshot proposal to Futarchy id `435` through `SnapshotLinkRegistry.upsert`.

## Details

- Adds action manifests, ABIs, validation, prechecks, simulation gating, receipt tracking, and postcheck display under `src/ops`.
- Adds the `/ops` page with the existing app shell, RainbowKit connect button, decoded transaction review, signer/chain gates, and disabled signing until checks pass.
- Adds a Netlify Edge Function gate for `/ops`, `/ops/`, `/ops.html`, and `/ops/index.html`; production requires `OPS_SIGNER_ACCESS_KEY` and otherwise returns 404.
- Documents the plan and proposed `/goal` command in `docs/OPS_SIGNER_PLAN.md`.

## Validation

- `npm run build-only` from a clean `origin/main` worktree passed.
- Playwright smoke checked `/ops` on desktop and mobile widths: one action card rendered, no horizontal overflow.
- Edge function harness checked missing env, wrong token, correct token redirect/cookie, signed cookie access, and direct `ops.html` block behavior.

## Notes

Existing build warnings remain unrelated to this change: static export header warnings, `DEFAULT_BASE_TOKENS_CONFIG` import warnings from market page components, and the MetaMask SDK optional async-storage warning.