### PR TITLE
[codex] filter ended milestones by metadata

### DIFF
--- a/src/components/futarchyFi/companyList/page/EventsHighlightDataTransformer.jsx
+++ b/src/components/futarchyFi/companyList/page/EventsHighlightDataTransformer.jsx
@@ -44,9 +44,13 @@ export const fetchEventHighlightData = async (_companyId = "all", options = {}) 
       return [];
     }
 
-    // Filter out resolved proposals — they belong in Recently Resolved, not Active Milestones
+    // Filter out resolved and closed proposals. Resolved proposals belong in
+    // Recently Resolved; closed unresolved proposals are over and should not
+    // remain in Active Milestones.
     const activeSubgraphEvents = subgraphEvents.filter(p =>
-      p.resolution_status !== 'resolved' && p.resolutionStatus !== 'resolved'
+      !p.isClosed &&
+      p.resolution_status !== 'resolved' &&
+      p.resolutionStatus !== 'resolved'
     );
 
     // Bulk fetch prices for the remaining events

--- a/src/hooks/useAggregatorCompanies.js
+++ b/src/hooks/useAggregatorCompanies.js
@@ -12,6 +12,7 @@
 import { useState, useEffect } from 'react';
 
 import { AGGREGATOR_SUBGRAPH_URL as SUBGRAPH_URL } from '../config/subgraphEndpoints';
+import { isProposalActive, isProposalArchived } from '../utils/proposalLifecycle';
 
 // Three flat queries — Checkpoint has no auto-generated reverse fields.
 const AGGREGATOR_QUERY = `
@@ -79,14 +80,10 @@ function transformOrgToCard(org, proposalsForOrg) {
     const chainId = meta.chain ? parseInt(meta.chain, 10) : 100;
 
     // "Total proposals" excludes archived ones (treat archive as a delete).
-    // "Active proposals" further excludes hidden + resolved.
-    const nonArchived = proposalsForOrg.filter(p => parseMetadata(p.metadata).archived !== true);
-    const active = nonArchived.filter(p => {
-        const pm = parseMetadata(p.metadata);
-        if (pm.visibility === 'hidden') return false;
-        if (pm.resolution_status === 'resolved' || pm.resolution_outcome) return false;
-        return true;
-    });
+    // "Active proposals" further excludes hidden, resolved, and closed markets.
+    const proposalMetadata = proposalsForOrg.map(p => parseMetadata(p.metadata));
+    const nonArchived = proposalMetadata.filter(pm => !isProposalArchived(pm));
+    const active = nonArchived.filter(pm => isProposalActive(pm));
 
     return {
         companyID: org.id,

--- a/src/hooks/useAggregatorProposals.js
+++ b/src/hooks/useAggregatorProposals.js
@@ -12,6 +12,12 @@ import { useState, useEffect } from 'react';
 
 // Subgraph endpoint for futarchy-complete (metadata hierarchy)
 import { AGGREGATOR_SUBGRAPH_URL as SUBGRAPH_URL } from '../config/subgraphEndpoints';
+import {
+    getProposalCloseTimestamp,
+    isProposalArchived,
+    isProposalClosed,
+    isProposalResolved,
+} from '../utils/proposalLifecycle';
 
 // The Checkpoint indexer doesn't auto-generate reverse relation fields,
 // so we issue three flat queries and assemble the legacy nested shape
@@ -114,24 +120,22 @@ function transformProposalToEvent(proposal, org, connectedWallet) {
     // Start time - no createdAt in subgraph, use current time as placeholder
     const startTimeSeconds = Math.floor(Date.now() / 1000);
 
-    // End time: prioritize closeTimestamp from metadata JSON
-    // closeTimestamp can be in seconds or milliseconds - normalize to seconds
-    let endTimeSeconds = startTimeSeconds + 7 * 24 * 60 * 60; // Default 7 days
-    if (proposalMeta.closeTimestamp) {
-        const closeTs = parseInt(proposalMeta.closeTimestamp);
-        // If timestamp > 10 billion, it's likely milliseconds
-        endTimeSeconds = closeTs > 10000000000 ? Math.floor(closeTs / 1000) : closeTs;
+    // End time: prioritize closeTimestamp from metadata JSON.
+    const closeTimestamp = getProposalCloseTimestamp(proposalMeta);
+    let endTimeSeconds = closeTimestamp || startTimeSeconds + 7 * 24 * 60 * 60; // Default 7 days
+    if (closeTimestamp) {
         console.log(`[🔗 CLOSE-TIME] Proposal "${proposal.displayNameEvent?.slice(0, 30)}..." closeTimestamp:`, {
             raw: proposalMeta.closeTimestamp,
             normalized: endTimeSeconds,
             date: new Date(endTimeSeconds * 1000).toISOString()
         });
-    } else if (proposalMeta.endTime) {
-        endTimeSeconds = proposalMeta.endTime;
     }
 
     // Visibility: 'public' (default), 'hidden' (staging/test - only for owner/editor)
     const visibility = proposalMeta.visibility || 'public';
+
+    const resolved = isProposalResolved(proposalMeta);
+    const closed = isProposalClosed(proposalMeta);
 
     return {
         // =============================================
@@ -167,11 +171,13 @@ function transformProposalToEvent(proposal, org, connectedWallet) {
         // Time info (seconds, not milliseconds)
         startTime: startTimeSeconds,
         endTime: endTimeSeconds,  // Uses closeTimestamp from metadata if available
+        closeTimestamp,
+        isClosed: closed,
         timeProgress: 0,
 
         // Status — use metadata resolution fields if available
-        status: proposalMeta.resolution_status === 'resolved' ? 'resolved' : 'ongoing',
-        resolutionStatus: proposalMeta.resolution_status || 'unresolved',
+        status: resolved ? 'resolved' : (closed ? 'ended' : 'ongoing'),
+        resolutionStatus: proposalMeta.resolution_status || (closed ? 'closed' : 'unresolved'),
         resolution_status: proposalMeta.resolution_status || null,
         resolution_outcome: proposalMeta.resolution_outcome || null,
         resolutionOutcome: proposalMeta.resolution_outcome || null,
@@ -431,7 +437,7 @@ export async function fetchProposalsFromAggregator(aggregatorAddress, connectedW
         for (const proposal of org.proposals || []) {
             // Skip archived proposals (test/abandoned, never going live)
             const proposalMeta = parseMetadata(proposal.metadata);
-            if (proposalMeta.archived === true) {
+            if (isProposalArchived(proposalMeta)) {
                 console.log(`[🗄️ ARCHIVED] Skipping "${proposal.displayNameEvent?.slice(0, 40)}..."`);
                 continue;
             }

--- a/src/utils/proposalLifecycle.js
+++ b/src/utils/proposalLifecycle.js
@@ -1,0 +1,37 @@
+export function normalizeUnixTimestamp(value) {
+    if (value === null || value === undefined || value === '') return null;
+
+    const numeric = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+    if (!Number.isFinite(numeric) || Number.isNaN(numeric) || numeric <= 0) return null;
+
+    return numeric > 10000000000 ? Math.floor(numeric / 1000) : numeric;
+}
+
+export function getProposalCloseTimestamp(metadata = {}) {
+    return normalizeUnixTimestamp(metadata.closeTimestamp ?? metadata.endTime);
+}
+
+export function isProposalArchived(metadata = {}) {
+    return metadata.archived === true || metadata.archived === 'true';
+}
+
+export function isProposalHidden(metadata = {}) {
+    return metadata.visibility === 'hidden';
+}
+
+export function isProposalResolved(metadata = {}) {
+    const outcome = metadata.resolution_outcome ?? metadata.finalOutcome;
+    return metadata.resolution_status === 'resolved' || (outcome !== null && outcome !== undefined && outcome !== '');
+}
+
+export function isProposalClosed(metadata = {}, nowSeconds = Math.floor(Date.now() / 1000)) {
+    const closeTimestamp = getProposalCloseTimestamp(metadata);
+    return closeTimestamp !== null && closeTimestamp <= nowSeconds;
+}
+
+export function isProposalActive(metadata = {}, nowSeconds = Math.floor(Date.now() / 1000)) {
+    return !isProposalArchived(metadata)
+        && !isProposalHidden(metadata)
+        && !isProposalResolved(metadata)
+        && !isProposalClosed(metadata, nowSeconds);
+}


### PR DESCRIPTION
## Summary

- Add shared proposal lifecycle helpers for archived, hidden, resolved, and closed metadata states.
- Treat proposals with past `closeTimestamp` or `endTime` metadata as inactive in `/companies` active proposal counts.
- Exclude closed proposals from the company Active Milestones list.

## Root Cause

KIP-88 has a metadata `closeTimestamp` of `1780660800` (`2026-06-05T12:00:00Z`) but no explicit `resolution_status`. The previous companies indexer/UI filters only excluded hidden, archived, resolved, or final-outcome proposals, so a proposal whose voting window had ended by timestamp could still be counted and displayed as active.

## Validation

- Probed live registry GraphQL metadata for KIP-88 and confirmed the new lifecycle logic marks it inactive as of `2026-06-24T00:00:00Z`.
- Ran focused proposal lifecycle checks for seconds, milliseconds, hidden, archived, resolved, outcome, past-close, and future-close cases.
- Ran `node --check` on the changed JS/JSX files.
- Ran `git diff --check` and `git diff --cached --check`.
- Ran focused Next lint for the changed files via the complete dependency install in `/Users/kas/interface`; no ESLint warnings or errors.

Note: a fresh `pnpm install` in `/Users/kas/interface-ops-signer` could not complete because the local filesystem hit `ENOSPC`, so I did not run a full build from that worktree.