### PR TITLE
[codex] default GIP-151 to subgraph chart

### DIFF
--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -2061,6 +2061,10 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     '0xFb45aE9d8e5874e85b8e23D735EB9718EfEF47Fa': {
       useSubgraph: 'only',
       useSpotPrice: 'composite::0xaa7a70070e7495fe86c67225329dbd39baa2f63b+0xc8cf54b0b70899ea846b70361e62f3f5b22b1f4binvert+0x3de27efa2f1aa663ae5d458857e731c129069f29invert-hour-100-eth'  // AAVE/GHO composite: USDC/GHO * AAVE/USDC(inv) * AAVE/GHO(inv)
+    },
+    '0xeCe80208CB8376Be311cE0f5Ea4eF73850a0dcF0': {
+      useSubgraph: 'only',
+      useSpotPrice: '0x8189c4c96826d016a99986394103dfa9ae41e7ee::0x89c80a4540a00b5270347e02e2e144c71da2eced-hour-500-xdai'  // GNO/WXDAI pool + sDAI rate provider
     }
   };
 
@@ -2074,7 +2078,10 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
 
   // Get proposal ID early for defaults lookup
   const proposalIdForDefaults = proposalIdFromPath || proposal?.address || proposal?.id || searchParams.get('proposalId');
-  const proposalDefaults = PROPOSAL_DEFAULTS[proposalIdForDefaults] || {};
+  const normalizedProposalIdForDefaults = proposalIdForDefaults?.toLowerCase?.();
+  const proposalDefaults = Object.entries(PROPOSAL_DEFAULTS).find(
+    ([address]) => address.toLowerCase() === normalizedProposalIdForDefaults
+  )?.[1] || {};
 
   // Apply defaults: URL params override proposal defaults
   // If global toggle is enabled, force subgraph for all proposals


### PR DESCRIPTION
## Summary

- default the GIP-151 market page to the subgraph-backed chart
- make proposal default matching case-insensitive so lowercase `proposalId` URLs pick up defaults
- preserve the same GNO/WXDAI spot overlay used by the other GNO markets

## Why

The default `TripleChart` path reads historical YES/NO candles from Supabase `pool_candles`. GIP-151 candles are present in the canonical candles/subgraph API, but not in Supabase, so the default chart path can render without YES/NO candles. `SubgraphChart` reads the data source that already has the corrected GIP-151 candles.

## Validation

- `git diff --check`
- Confirmed GIP-151 metadata `startCandleUnix = 1782298800` (`2026-06-24T11:00:00Z`), which includes the corrected 11:00 bucket and excludes stale 09:00/prior-day `97.3` candles.
- Confirmed candles API has corrected GIP-151 rows after the new start: YES has corrected `84.65135420260654`, `84.65300796139223`, `84.65962270065558`; NO has corrected `84.65135420260654`.
- Confirmed Snapshot-ID chart route resolves through metadata fallback.

Local production build could not be completed in this checkout because dependency install hangs/fails inside a nested git package peer install; Netlify should run the clean production build from `main` after merge.
