### PR TITLE
Update landing page headline

### DIFF
--- a/app/metadata.js
+++ b/app/metadata.js
@@ -1,8 +1,8 @@
 export default {
-  title: "Futarchy.fi - Markets Know Better Than Experts",
+  title: "Futarchy.fi - Markets Know Better",
   description: "It's time we let markets decide. Harness collective intelligence through market mechanisms to guide decision-making in your organization.",
   openGraph: {
-    title: "Futarchy.fi - Markets Know Better Than Experts",
+    title: "Futarchy.fi - Markets Know Better",
     description: "It's time we let markets decide. Harness collective intelligence through market mechanisms to guide decision-making in your organization.",
     url: "https://futarchy.fi",
     siteName: "Futarchy.fi",
@@ -12,7 +12,7 @@ export default {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Futarchy.fi - Markets Know Better Than Experts",
+    title: "Futarchy.fi - Markets Know Better",
     description: "It's time we let markets decide. Harness collective intelligence through market mechanisms to guide decision-making in your organization.",
     // TODO: Add OG image for Twitter card
   },

--- a/src/components/futarchyFi/landingPage/LandingPage.jsx
+++ b/src/components/futarchyFi/landingPage/LandingPage.jsx
@@ -423,7 +423,7 @@ const LandingPage = ({ useStorybookUrl = false }) => {
                         }}
                         startDelay={100}
                         cursorColor="transparent"
-                        text="Markets know better than experts."
+                        text="Markets know better."
                         typeSpeed={35}
                       />
                       <div className="flex flex-row gap-3">
@@ -527,7 +527,7 @@ const LandingPage = ({ useStorybookUrl = false }) => {
                         }}
                         startDelay={100}
                         cursorColor="transparent"
-                        text="Markets know better than experts."
+                        text="Markets know better."
                         typeSpeed={70}
                       />
 


### PR DESCRIPTION
Summary:
- Change the landing page headline from "Markets know better than experts." to "Markets know better." on desktop and mobile.
- Update default Open Graph and Twitter preview titles to remove "Than Experts".

Verification:
- Built static export with npm run build.
- Deployed the verified out/ artifact to production Netlify: https://futarchy.fi
- Confirmed live homepage metadata contains "Futarchy.fi - Markets Know Better".

Note: production is already deployed from commit 9ff3e94; merging this PR keeps main in sync.