### PR TITLE
Route ended proposals to Recently Closed

### DIFF
--- a/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
+++ b/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
@@ -152,10 +152,13 @@ const Timestamp = ({ endTime }) => {
   ) : null;
 };
 
-// Component to show resolved status badge
-const ResolvedStatusBadge = () => (
-  <div className="w-fit px-2 py-0.5 text-start rounded-full text-xs bg-emerald-100 dark:bg-emerald-900/30 border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400 font-medium mt-1">
-    ✓ Resolved
+// Component to show completed status badge
+const CompletedStatusBadge = ({ label }) => (
+  <div className={`w-fit px-2 py-0.5 text-start rounded-full text-xs font-medium mt-1 ${label === 'Resolved'
+    ? 'bg-emerald-100 dark:bg-emerald-900/30 border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400'
+    : 'bg-futarchyGold9/35 border border-futarchyGold9 text-futarchyGold11 dark:border-futarchyGold6 dark:bg-futarchyGold7/15 dark:text-futarchyGold6'
+    }`}>
+    {label === 'Resolved' ? '✓ Resolved' : 'Closed'}
   </div>
 );
 
@@ -182,6 +185,7 @@ const HighlightCard = ({
   useMockData = false,
   // New props for resolved events
   isResolved = false,
+  isClosed = false,
   resolutionOutcome,
   finalOutcome,
   impact: impactProp,
@@ -226,6 +230,7 @@ const HighlightCard = ({
   };
 
   const { marketName, endTime, proposalCreationTimestamp, companyLogoUrl, status, marketId } = data;
+  const isComplete = isResolved || isClosed;
 
   // Extract display titles from metadata (similar to EventHighlightCard)
   const displayTitle0 = metadata?.display_title_0 || null;
@@ -261,7 +266,7 @@ const HighlightCard = ({
   // Use dynamic price fetching for resolved events if poolAddresses are provided
   // Pass prefetchedPrices to skip Supabase fetch when available
   const { prices: fetchedPrices, loading: isPriceLoading } = useLatestPoolPrices(
-    isResolved && poolAddresses ? poolAddresses : null,
+    isComplete && poolAddresses ? poolAddresses : null,
     marketId,
     metadata,
     prefetchedPrices
@@ -273,12 +278,12 @@ const HighlightCard = ({
     : 'supabase';
 
   // Determine which prices to use - fetched for resolved events or props for active events
-  const priceYes = isResolved && fetchedPrices.yes !== null ? fetchedPrices.yes : parsePrice(data.priceYes);
-  const priceNo = isResolved && fetchedPrices.no !== null ? fetchedPrices.no : parsePrice(data.priceNo);
+  const priceYes = isComplete && fetchedPrices.yes !== null ? fetchedPrices.yes : parsePrice(data.priceYes);
+  const priceNo = isComplete && fetchedPrices.no !== null ? fetchedPrices.no : parsePrice(data.priceNo);
   const priceSpot = parsePrice(data.priceSpot);
   const eventProbability = parsePrice(data.eventProbability);
 
-  const isLoading = status === "Loading" || (isResolved && isPriceLoading);
+  const isLoading = status === "Loading" || (isComplete && isPriceLoading);
   const isError = status === "Error";
 
   const impact = useMemo(() => {
@@ -292,8 +297,8 @@ const HighlightCard = ({
       }
     }
 
-    // Fallback for resolved events: use provided impact value if no prices available
-    if (isResolved && impactProp !== undefined && impactProp !== null) {
+    // Fallback for completed events: use provided impact value if no prices available
+    if (isComplete && impactProp !== undefined && impactProp !== null) {
       const numericImpact = typeof impactProp === 'string' ? parseFloat(impactProp) : impactProp;
       if (typeof numericImpact === 'number' && !isNaN(numericImpact)) {
         return numericImpact >= 0 ? `+${numericImpact.toFixed(2)}%` : `${numericImpact.toFixed(2)}%`;
@@ -307,7 +312,7 @@ const HighlightCard = ({
     }
 
     return "N/A";
-  }, [priceYes, priceNo, priceSpot, isResolved, impactProp]);
+  }, [priceYes, priceNo, priceSpot, isComplete, impactProp]);
 
   const isImpactPositive = impact !== "N/A" && !impact.startsWith("-");
   const impactTextColorClass = isImpactPositive ? "text-futarchyTeal9 dark:text-futarchyTeal9" : "text-futarchyCrimson9 dark:text-futarchyCrimson9";
@@ -344,12 +349,13 @@ const HighlightCard = ({
 
   const outcome = finalOutcome || resolutionOutcome;
   const isYesOutcome = outcome?.toLowerCase() === 'yes';
+  const completionLabel = outcome ? 'Resolved' : 'Closed';
 
-  const statItems = isResolved ? [
-    // For resolved events, show outcome and impact
+  const statItems = isComplete ? [
+    // For completed events, show outcome when available; otherwise mark as closed.
     {
-      label: "Outcome",
-      value: outcome ? outcome.toUpperCase() : 'Unknown',
+      label: outcome ? "Outcome" : "Status",
+      value: outcome ? outcome.toUpperCase() : 'Closed',
       colorClass: isYesOutcome ? "text-futarchyBlue9 dark:text-futarchyBlue9" : "text-futarchyGold8 dark:text-futarchyGold8",
     },
     {
@@ -462,7 +468,7 @@ const HighlightCard = ({
                 marketName || "Untitled Market"
               )}
             </h3>
-            {isResolved ? <ResolvedStatusBadge /> : <Timestamp endTime={endTime} />}
+            {isComplete ? <CompletedStatusBadge label={completionLabel} /> : <Timestamp endTime={endTime} />}
           </div>
         </div>
       </div>
@@ -472,7 +478,7 @@ const HighlightCard = ({
 
       {/* Bottom Section - grows to fill space */}
       <div className="p-4 bg-futarchyGray3 dark:bg-futarchyDarkGray3 flex-grow flex items-end">
-        <div className={`grid ${isResolved ? 'grid-cols-2' : 'grid-cols-3'} md:gap-1 gap-3 w-full`}>
+        <div className={`grid ${isComplete ? 'grid-cols-2' : 'grid-cols-3'} md:gap-1 gap-3 w-full`}>
           {statItems.map((item) => (
             <div
               key={item.label}

--- a/src/components/futarchyFi/companyList/components/ResolvedEventsCarousel.jsx
+++ b/src/components/futarchyFi/companyList/components/ResolvedEventsCarousel.jsx
@@ -49,7 +49,7 @@ const ResolvedEventsCarousel = ({ companyId = "all", limit = 10, aggregatorAddre
         const data = await fetchResolvedEventHighlightData(companyId, limit, { connectedWallet, aggregatorAddress });
         setResolvedEvents(data);
       } catch (error) {
-        console.error('Error loading resolved event highlights:', error);
+        console.error('Error loading closed event highlights:', error);
       } finally {
         setLoading(false);
       }
@@ -59,8 +59,7 @@ const ResolvedEventsCarousel = ({ companyId = "all", limit = 10, aggregatorAddre
   }, [companyId, limit, connectedWallet, aggregatorAddress]);
 
   useEffect(() => {
-    // For resolved events, we typically want to show all regardless of debug mode
-    // since they're already completed and resolved
+    // Closed/completed events should show regardless of debug mode.
     setFilteredEvents(resolvedEvents);
   }, [resolvedEvents, debugMode]);
 
@@ -102,7 +101,7 @@ const ResolvedEventsCarousel = ({ companyId = "all", limit = 10, aggregatorAddre
     return (
       <div className="flex flex-col justify-center items-center h-[200px] text-futarchyGray11">
         <div className="text-4xl mb-2">🏁</div>
-        <div className="text-sm">No resolved markets yet</div>
+        <div className="text-sm">No closed markets yet</div>
       </div>
     );
   }
@@ -138,9 +137,10 @@ const ResolvedEventsCarousel = ({ companyId = "all", limit = 10, aggregatorAddre
               marketName={event.eventTitle}
               companyLogoUrl={event.companyLogo}
               endTime={event.endTime}
-              proposalCreationTimestamp={event.endTime} // For resolved events, use endTime as proposal time
+              proposalCreationTimestamp={event.endTime} // For closed events, use endTime as proposal time
               status="Done"
-              isResolved={true}
+              isResolved={event.isResolved}
+              isClosed={event.isClosed}
               resolutionOutcome={event.resolutionOutcome}
               finalOutcome={event.finalOutcome}
               impact={event.impact}

--- a/src/components/futarchyFi/companyList/page/CompaniesPage.jsx
+++ b/src/components/futarchyFi/companyList/page/CompaniesPage.jsx
@@ -18,8 +18,8 @@ import { CONTRACT_ADDRESSES } from "../../marketPage/constants/contracts";
 import { ENABLE_V2_SUBGRAPH } from "../../../../config/featureFlags";
 
 // Configuration flags
-// Recently Resolved now works with V2 subgraph via fetchProposalsFromAggregator
-const HIDE_RECENTLY_RESOLVED = false;
+// Recently Closed works with V2 subgraph via fetchProposalsFromAggregator
+const HIDE_RECENTLY_CLOSED = false;
 
 const CompaniesPage = ({ useStorybookUrl = false }) => {
   const { address: connectedWallet } = useAccount();
@@ -97,11 +97,11 @@ const CompaniesPage = ({ useStorybookUrl = false }) => {
           )}
         </div>
 
-        {/* Recently Resolved Section */}
-        {!HIDE_RECENTLY_RESOLVED && (
+        {/* Recently Closed Section */}
+        {!HIDE_RECENTLY_CLOSED && (
           <div className="mb-12 mt-8 md:mt-10">
             <h2 className="text-2xl font-semibold text-futarchyGray12 dark:text-white mb-6">
-              Recently Resolved
+              Recently Closed
             </h2>
             {isResolvedCarouselLoading ? (
               <div className="flex justify-center items-center h-[200px]">
@@ -111,7 +111,7 @@ const CompaniesPage = ({ useStorybookUrl = false }) => {
               <ResolvedEventsCarousel
                 companyId="all"
                 limit={10}
-                aggregatorAddress={DEFAULT_AGGREGATOR}
+                aggregatorAddress={aggregatorAddress}
                 connectedWallet={connectedWallet}
                 onEditProposal={(proposalMetadataAddress) => {
                   setEditProposalModal({ isOpen: true, proposalMetadataAddress });

--- a/src/components/futarchyFi/companyList/page/EventsHighlightDataTransformer.jsx
+++ b/src/components/futarchyFi/companyList/page/EventsHighlightDataTransformer.jsx
@@ -1,13 +1,14 @@
 import { collectAndFetchPoolPrices, attachPrefetchedPrices } from "../../../../utils/SubgraphBulkPriceFetcher";
 import { fetchProposalsFromAggregator } from "../../../../hooks/useAggregatorProposals";
 import { DEFAULT_AGGREGATOR } from "../../../../config/subgraphEndpoints";
+import { isClosedProposal, isResolvedProposal } from "../../../../utils/proposalLifecycle";
 
 // Main function to fetch active milestones from the registry subgraph aggregator.
 // Returns proposals filtered by visibility (hidden visible only to owner/editor)
-// and by status (resolved proposals are excluded; they belong in Recently Resolved).
+// and by lifecycle (resolved or ended proposals belong in Recently Closed).
 export const fetchEventHighlightData = async (_companyId = "all", options = {}) => {
-  const aggregatorAddress = DEFAULT_AGGREGATOR;
-  const { connectedWallet } = options;
+  const { connectedWallet, aggregatorAddress: requestedAggregatorAddress } = options;
+  const aggregatorAddress = requestedAggregatorAddress || DEFAULT_AGGREGATOR;
 
   try {
     let subgraphEvents = [];
@@ -44,13 +45,13 @@ export const fetchEventHighlightData = async (_companyId = "all", options = {}) 
       return [];
     }
 
-    // Filter out resolved and closed proposals. Resolved proposals belong in
-    // Recently Resolved; closed unresolved proposals are over and should not
-    // remain in Active Milestones.
+    const nowSeconds = Date.now() / 1000;
+
+    // Filter out resolved and ended proposals. Ended proposals may still have
+    // stale/missing resolution metadata, but they should not disappear from the
+    // homepage; Recently Closed owns that state.
     const activeSubgraphEvents = subgraphEvents.filter(p =>
-      !p.isClosed &&
-      p.resolution_status !== 'resolved' &&
-      p.resolutionStatus !== 'resolved'
+      !isResolvedProposal(p) && !isClosedProposal(p, nowSeconds)
     );
 
     // Bulk fetch prices for the remaining events

--- a/src/components/futarchyFi/companyList/page/ResolvedEventsDataTransformer.jsx
+++ b/src/components/futarchyFi/companyList/page/ResolvedEventsDataTransformer.jsx
@@ -1,80 +1,100 @@
 import { collectAndFetchPoolPrices, attachPrefetchedPrices } from "../../../../utils/SubgraphBulkPriceFetcher";
 import { fetchProposalsFromAggregator } from "../../../../hooks/useAggregatorProposals";
 import { DEFAULT_AGGREGATOR } from "../../../../config/subgraphEndpoints";
+import { getProposalEndTime, hasResolutionOutcome, isClosedProposal, isResolvedProposal } from "../../../../utils/proposalLifecycle";
 
-const filterRecentResolvedEvents = (events) => {
-  // Bypassing the recent filter so all resolved markets are shown permanently
+const filterRecentClosedEvents = (events) => {
+  // Bypassing the recent filter so all closed markets are shown permanently
   return events;
 };
 
-// Fetch resolved proposals from the registry subgraph aggregator.
+// Fetch recently closed proposals from the registry subgraph aggregator.
+// A proposal is closed when its metadata marks it resolved or when its close
+// timestamp has passed, even if resolution metadata has not been repaired yet.
 export const fetchResolvedEventHighlightData = async (_companyId = "all", limit = 10, options = {}) => {
-  const { connectedWallet } = options;
-  const aggregatorAddress = DEFAULT_AGGREGATOR;
+  const { connectedWallet, aggregatorAddress: requestedAggregatorAddress } = options;
+  const aggregatorAddress = requestedAggregatorAddress || DEFAULT_AGGREGATOR;
 
   try {
     const { proposals } = await fetchProposalsFromAggregator(aggregatorAddress, connectedWallet);
 
-    const resolvedProposals = proposals.filter(p => {
+    const nowSeconds = Date.now() / 1000;
+
+    const closedProposals = proposals.filter(p => {
       // Skip proposals from archived/hidden orgs (same rule as Active Milestones)
       const orgMeta = p.orgMetadata || {};
       if (orgMeta.archived === true) return false;
       if (orgMeta.visibility === 'hidden' && !p.isEditor) return false;
 
-      return p.resolution_status === 'resolved'
-        && p.resolution_outcome !== null
-        && p.resolution_outcome !== undefined;
+      const visibility = p.visibility || 'public';
+      if (visibility === 'hidden') {
+        return p.isOwner || p.isEditor;
+      }
+
+      return isResolvedProposal(p) || isClosedProposal(p, nowSeconds);
     });
 
-    console.log(`[ResolvedEventsDataTransformer] Found ${resolvedProposals.length} resolved proposals from subgraph (of ${proposals.length} total)`);
-    if (resolvedProposals.length === 0) return [];
+    console.log(`[ResolvedEventsDataTransformer] Found ${closedProposals.length} closed proposals from subgraph (of ${proposals.length} total)`);
+    if (closedProposals.length === 0) return [];
 
-    const resolvedEvents = resolvedProposals.map(proposal => ({
-      eventId: proposal.eventId || proposal.proposalAddress,
-      eventTitle: proposal.eventTitle || proposal.proposalTitle || 'Unknown Proposal',
-      companyLogo: proposal.companyLogo || '/assets/fallback-company.png',
-      authorName: proposal.authorName || 'Unknown Organization',
-      resolutionStatus: proposal.resolutionStatus || proposal.resolution_status,
-      resolutionOutcome: proposal.resolutionOutcome || proposal.resolution_outcome,
-      finalOutcome: proposal.finalOutcome || proposal.resolution_outcome,
-      impact: typeof proposal.metadata?.impact === 'number'
-        ? proposal.metadata.impact
-        : (typeof proposal.metadata?.impact === 'string' ? parseFloat(proposal.metadata.impact) : 0),
-      poolAddresses: proposal.poolAddresses || { yes: null, no: null },
-      endTime: proposal.endTime,
-      endDate: proposal.endTime ? new Date(proposal.endTime * 1000).toISOString() : null,
-      metadata: proposal.metadata,
-      companyId: proposal.companyId,
-      companySymbol: proposal.metadata?.companyTokens?.base?.tokenSymbol || 'GNO',
-      currencySymbol: proposal.metadata?.currencyTokens?.base?.tokenSymbol || 'sDAI',
-      displayTitle0: proposal.metadata?.display_title_0,
-      displayTitle1: proposal.metadata?.display_title_1,
-      description: proposal.description || 'No description available',
-      chainId: proposal.chainId || 100,
-      isOwner: proposal.isOwner,
-      isEditor: proposal.isEditor,
-      fromSubgraph: proposal.fromSubgraph,
-      proposalMetadataAddress: proposal.proposalMetadataAddress,
-      visibility: proposal.visibility
-    }));
+    const closedEvents = closedProposals.map(proposal => {
+      const endTime = getProposalEndTime(proposal);
+      const hasOutcome = hasResolutionOutcome(proposal);
+      const isResolved = isResolvedProposal(proposal);
+      const isClosed = isClosedProposal(proposal, nowSeconds);
+      const resolutionOutcome = proposal.resolutionOutcome ?? proposal.resolution_outcome ?? null;
 
-    const recentResolved = filterRecentResolvedEvents(resolvedEvents);
-    if (recentResolved.length === 0) return [];
+      return {
+        eventId: proposal.eventId || proposal.proposalAddress,
+        eventTitle: proposal.eventTitle || proposal.proposalTitle || 'Unknown Proposal',
+        companyLogo: proposal.companyLogo || '/assets/fallback-company.png',
+        authorName: proposal.authorName || 'Unknown Organization',
+        resolutionStatus: isResolved && hasOutcome
+          ? 'resolved'
+          : (isClosed ? 'closed' : (proposal.resolutionStatus || proposal.resolution_status)),
+        resolutionOutcome,
+        finalOutcome: proposal.finalOutcome ?? resolutionOutcome,
+        impact: typeof proposal.metadata?.impact === 'number'
+          ? proposal.metadata.impact
+          : (typeof proposal.metadata?.impact === 'string' ? parseFloat(proposal.metadata.impact) : 0),
+        poolAddresses: proposal.poolAddresses || { yes: null, no: null },
+        endTime,
+        endDate: endTime ? new Date(endTime * 1000).toISOString() : null,
+        metadata: proposal.metadata,
+        companyId: proposal.companyId,
+        companySymbol: proposal.metadata?.companyTokens?.base?.tokenSymbol || 'GNO',
+        currencySymbol: proposal.metadata?.currencyTokens?.base?.tokenSymbol || 'sDAI',
+        displayTitle0: proposal.metadata?.display_title_0,
+        displayTitle1: proposal.metadata?.display_title_1,
+        description: proposal.description || 'No description available',
+        chainId: proposal.chainId || 100,
+        isOwner: proposal.isOwner,
+        isEditor: proposal.isEditor,
+        fromSubgraph: proposal.fromSubgraph,
+        proposalMetadataAddress: proposal.proposalMetadataAddress,
+        visibility: proposal.visibility,
+        isResolved,
+        isClosed: isClosed || isResolved
+      };
+    });
 
-    recentResolved.sort((a, b) => {
-      const aTime = new Date(a.endDate || a.endTime * 1000).getTime();
-      const bTime = new Date(b.endDate || b.endTime * 1000).getTime();
+    const recentClosed = filterRecentClosedEvents(closedEvents);
+    if (recentClosed.length === 0) return [];
+
+    recentClosed.sort((a, b) => {
+      const aTime = a.endTime ? a.endTime * 1000 : 0;
+      const bTime = b.endTime ? b.endTime * 1000 : 0;
       return bTime - aTime;
     });
 
-    const limitedResults = recentResolved.slice(0, limit);
+    const limitedResults = recentClosed.slice(0, limit);
 
     const priceMap = await collectAndFetchPoolPrices(limitedResults);
     attachPrefetchedPrices(limitedResults, priceMap);
 
     return limitedResults;
   } catch (error) {
-    console.error("Error fetching resolved event highlights:", error);
+    console.error("Error fetching closed event highlights:", error);
     return [];
   }
 };

--- a/src/utils/proposalLifecycle.js
+++ b/src/utils/proposalLifecycle.js
@@ -1,10 +1,25 @@
 export function normalizeUnixTimestamp(value) {
     if (value === null || value === undefined || value === '') return null;
 
-    const numeric = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
-    if (!Number.isFinite(numeric) || Number.isNaN(numeric) || numeric <= 0) return null;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || value <= 0) return null;
+        return value > 10000000000 ? Math.floor(value / 1000) : Math.floor(value);
+    }
 
-    return numeric > 10000000000 ? Math.floor(numeric / 1000) : numeric;
+    const trimmed = String(value).trim();
+    if (!trimmed) return null;
+
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric) && numeric > 0) {
+        return normalizeUnixTimestamp(numeric);
+    }
+
+    const parsedMs = Date.parse(trimmed);
+    if (Number.isFinite(parsedMs)) {
+        return Math.floor(parsedMs / 1000);
+    }
+
+    return null;
 }
 
 export function getProposalCloseTimestamp(metadata = {}) {
@@ -34,4 +49,47 @@ export function isProposalActive(metadata = {}, nowSeconds = Math.floor(Date.now
         && !isProposalHidden(metadata)
         && !isProposalResolved(metadata)
         && !isProposalClosed(metadata, nowSeconds);
+}
+
+export function getProposalEndTime(proposal = {}) {
+    return normalizeUnixTimestamp(
+        proposal.endTime ??
+        proposal.closeTimestamp ??
+        proposal.end_time ??
+        proposal.endDate ??
+        proposal.closeDate ??
+        proposal.metadata?.closeTimestamp ??
+        proposal.metadata?.endTime ??
+        proposal.metadata?.end_time
+    );
+}
+
+export function hasResolutionOutcome(proposal = {}) {
+    const outcome =
+        proposal.resolution_outcome ??
+        proposal.resolutionOutcome ??
+        proposal.finalOutcome ??
+        proposal.metadata?.resolution_outcome ??
+        proposal.metadata?.resolutionOutcome ??
+        proposal.metadata?.finalOutcome;
+
+    return outcome !== null && outcome !== undefined && outcome !== '';
+}
+
+export function isResolvedProposal(proposal = {}) {
+    const status =
+        proposal.resolution_status ??
+        proposal.resolutionStatus ??
+        proposal.status ??
+        proposal.metadata?.resolution_status ??
+        proposal.metadata?.resolutionStatus;
+
+    return status === 'resolved' || hasResolutionOutcome(proposal);
+}
+
+export function isClosedProposal(proposal = {}, nowSeconds = Math.floor(Date.now() / 1000)) {
+    if (proposal.isClosed === true) return true;
+
+    const endTime = getProposalEndTime(proposal);
+    return endTime !== null && endTime <= nowSeconds;
 }


### PR DESCRIPTION
## Summary
- route ended proposals out of Active Milestones and into the completed carousel even when resolution metadata is stale
- rename the homepage completed section to Recently Closed and distinguish Closed from Resolved cards
- reuse the existing proposal lifecycle helper for raw metadata and transformed proposal objects

## Root Cause
Ended proposals were filtered out of Active Milestones, but the completed carousel only accepted proposals with resolved metadata and an outcome. If metadata stayed `unresolved`, a proposal could disappear from both sections.

## Validation
- `NODE_PATH=/Users/kas/interface/node_modules /Users/kas/interface/node_modules/.bin/eslint ...` on touched files: 0 errors, existing warnings only in `HighlightCards.jsx`
- registry probe: current GIP-151 is closed/resolved; simulated stale GIP-151 remains excluded from Active and included in Recently Closed
- local Next compile: `curl -I http://127.0.0.1:3002/companies` returned 200
