### PR TITLE
[codex] Add permissionless market creation flow

### DIFF
--- a/auto-qa/tests/market-creation-workflow.test.mjs
+++ b/auto-qa/tests/market-creation-workflow.test.mjs
@@ -17,6 +17,7 @@ const {
   KNOWN_ORGANIZATIONS,
   MARKET_CREATION_STAGES,
   PERMISSIONLESS_STACK_STAGES,
+  validateContractActionDependencies,
   validateOneStepMarketPlan,
 } = workflow;
 
@@ -69,6 +70,15 @@ test('metadata draft includes registry fields needed by market pages and proposa
   assert.equal(draft.companyTokens.base.tokenSymbol, 'PNK');
   assert.equal(draft.currencyTokens.base.tokenSymbol, 'sDAI');
   assert.equal(draft.flm.mode, 'flm');
+  assert.equal(draft.snapshot.visibilityMetadata.includeOnSnapshotWebsite, true);
+  assert.equal(
+    draft.registry.proposalMetadataMethod,
+    'FutarchyOrganizationMetadata.createAndAddProposalMetadata'
+  );
+  assert.equal(
+    draft.registry.defaultLiquidityManagerMethod,
+    'FutarchyOrganizationMetadata.setDefaultLiquidityManager'
+  );
 });
 
 test('permissionless stack plan includes org listing, owner proposals, and default FLM', () => {
@@ -80,7 +90,47 @@ test('permissionless stack plan includes org listing, owner proposals, and defau
   assert.ok(stageIds.includes('list-organization'));
   assert.ok(stageIds.includes('default-flm'));
   assert.ok(stageIds.includes('owner-proposal'));
+  assert.ok(stageIds.indexOf('default-flm') < stageIds.indexOf('create-organization'));
   assert.equal(plan.values.chainId, 10200);
+});
+
+test('permissionless contract actions create FLM before default organization wiring', () => {
+  const plan = buildPermissionlessStackPlan();
+  const actions = plan.contractActions;
+  const actionIds = actions.map((action) => action.id);
+  const createFlm = actions.find((action) => action.id === 'create-default-flm-bundle');
+  const createOrganization = actions.find((action) => action.id === 'create-and-list-organization');
+
+  assert.equal(validateContractActionDependencies(actions).ok, true);
+  assert.equal(createFlm.contract, 'FutarchyLiquidityManagerFactory');
+  assert.equal(createFlm.method, 'createLiquidityManager');
+  assert.equal(createOrganization.contract, 'FutarchyAggregatorsMetadata');
+  assert.equal(createOrganization.method, 'createAndAddOrganizationMetadataWithDefaultLiquidityManager');
+  assert.ok(createOrganization.dependsOn.includes('create-default-flm-bundle'));
+  assert.ok(actionIds.indexOf('create-default-flm-bundle') < actionIds.indexOf('create-and-list-organization'));
+});
+
+test('one-step market contract actions order market, FLM, official proposal, liquidity, and Snapshot', () => {
+  const plan = buildOneStepMarketPlan({ organizationId: 'kleros', nowSeconds: NOW });
+  const actions = plan.contractActions;
+  const actionIds = actions.map((action) => action.id);
+  const createMarket = actions.find((action) => action.id === 'create-futarchy-proposal');
+  const createFlm = actions.find((action) => action.id === 'create-flm-bundle');
+  const setOfficialProposal = actions.find((action) => action.id === 'set-official-proposal');
+  const linkSnapshot = actions.find((action) => action.id === 'link-snapshot-proposal');
+
+  assert.equal(validateContractActionDependencies(actions).ok, true);
+  assert.equal(createMarket.contract, 'IFutarchyFactory');
+  assert.equal(createMarket.method, 'createProposal');
+  assert.equal(createFlm.contract, 'FutarchyLiquidityManagerFactory');
+  assert.equal(createFlm.method, 'createLiquidityManager');
+  assert.equal(setOfficialProposal.contract, 'FutarchyOfficialProposalSource');
+  assert.equal(setOfficialProposal.method, 'setOfficialProposal');
+  assert.ok(setOfficialProposal.dependsOn.includes('create-futarchy-proposal'));
+  assert.ok(linkSnapshot.dependsOn.includes('bootstrap-flm-liquidity'));
+  assert.ok(actionIds.indexOf('create-flm-bundle') < actionIds.indexOf('set-official-proposal'));
+  assert.ok(actionIds.indexOf('set-official-proposal') < actionIds.indexOf('bootstrap-flm-liquidity'));
+  assert.ok(actionIds.indexOf('bootstrap-flm-liquidity') < actionIds.indexOf('link-snapshot-proposal'));
 });
 
 test('validation rejects flows that would link Snapshot before liquidity', () => {

--- a/auto-qa/tests/market-creation-workflow.test.mjs
+++ b/auto-qa/tests/market-creation-workflow.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sourcePath = resolve(here, '../../src/features/marketCreation/marketCreationWorkflow.js');
+const source = await readFile(sourcePath, 'utf8');
+const workflow = await import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`);
+
+const {
+  buildMetadataDraft,
+  buildOneStepMarketPlan,
+  buildPermissionlessStackPlan,
+  createMarketWizardDefaults,
+  KNOWN_ORGANIZATIONS,
+  MARKET_CREATION_STAGES,
+  PERMISSIONLESS_STACK_STAGES,
+  validateOneStepMarketPlan,
+} = workflow;
+
+const NOW = 1_782_777_600;
+
+test('Kleros defaults use KIP, PNK, sDAI, and FLM liquidity', () => {
+  const defaults = createMarketWizardDefaults({ organizationId: 'kleros', nowSeconds: NOW });
+
+  assert.equal(defaults.organizationName, 'Kleros DAO');
+  assert.equal(defaults.proposalCode, 'KIP-90');
+  assert.equal(defaults.companyToken.symbol, 'PNK');
+  assert.equal(defaults.currencyToken.symbol, 'sDAI');
+  assert.equal(defaults.initialLiquidityMode, 'flm');
+  assert.equal(defaults.snapshotLinkAfterLiquidity, true);
+});
+
+test('Gnosis defaults use GIP, GNO, sDAI, and Gnosis Snapshot space', () => {
+  const defaults = createMarketWizardDefaults({ organizationId: 'gnosis', nowSeconds: NOW });
+
+  assert.equal(defaults.organizationName, 'Gnosis DAO');
+  assert.equal(defaults.proposalCode, 'GIP-151');
+  assert.equal(defaults.companyToken.symbol, 'GNO');
+  assert.equal(defaults.currencyToken.symbol, 'sDAI');
+  assert.equal(KNOWN_ORGANIZATIONS.gnosis.snapshotSpace, 'gnosis.eth');
+});
+
+test('one-step market plan covers the operational stages in required order', () => {
+  const plan = buildOneStepMarketPlan({ organizationId: 'kleros', nowSeconds: NOW });
+  const stageIds = plan.stages.map((stage) => stage.id);
+
+  assert.deepEqual(stageIds, MARKET_CREATION_STAGES.map((stage) => stage.id));
+  assert.ok(stageIds.indexOf('liquidity') < stageIds.indexOf('snapshot'));
+  assert.ok(stageIds.includes('metadata'));
+  assert.ok(stageIds.includes('indexing'));
+  assert.ok(stageIds.includes('arbitrage'));
+  assert.ok(stageIds.includes('publish'));
+});
+
+test('metadata draft includes registry fields needed by market pages and proposal routing', () => {
+  const draft = buildMetadataDraft({
+    organizationId: 'kleros',
+    nowSeconds: NOW,
+    snapshotId: '0xba2749a4f1283da9d1ca925d9f17bf712fa06a23e6a07d759c54340277820932',
+  });
+
+  assert.equal(draft.chain, 100);
+  assert.equal(draft.snapshot_id, '0xba2749a4f1283da9d1ca925d9f17bf712fa06a23e6a07d759c54340277820932');
+  assert.equal(draft.resolution_status, 'unresolved');
+  assert.equal(draft.visibility, 'public');
+  assert.equal(draft.companyTokens.base.tokenSymbol, 'PNK');
+  assert.equal(draft.currencyTokens.base.tokenSymbol, 'sDAI');
+  assert.equal(draft.flm.mode, 'flm');
+});
+
+test('permissionless stack plan includes org listing, owner proposals, and default FLM', () => {
+  const plan = buildPermissionlessStackPlan();
+  const stageIds = plan.stages.map((stage) => stage.id);
+
+  assert.deepEqual(stageIds, PERMISSIONLESS_STACK_STAGES.map((stage) => stage.id));
+  assert.ok(stageIds.includes('create-organization'));
+  assert.ok(stageIds.includes('list-organization'));
+  assert.ok(stageIds.includes('default-flm'));
+  assert.ok(stageIds.includes('owner-proposal'));
+  assert.equal(plan.values.chainId, 10200);
+});
+
+test('validation rejects flows that would link Snapshot before liquidity', () => {
+  const validPlan = buildOneStepMarketPlan({ organizationId: 'gnosis', nowSeconds: NOW });
+  assert.equal(validateOneStepMarketPlan(validPlan, { nowSeconds: NOW }).ok, true);
+
+  const invalidPlan = buildOneStepMarketPlan({
+    organizationId: 'gnosis',
+    nowSeconds: NOW,
+    snapshotLinkAfterLiquidity: false,
+  });
+  assert.deepEqual(validateOneStepMarketPlan(invalidPlan).errors, ['snapshotLinkAfterLiquidity']);
+});

--- a/src/components/futarchyFi/companyList/page/CompaniesPage.jsx
+++ b/src/components/futarchyFi/companyList/page/CompaniesPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import { useAccount } from 'wagmi';
 import RootLayout from "../../../layout/RootLayout";
 import { fetchEventHighlightData } from "./EventsHighlightDataTransformer";
@@ -122,10 +123,16 @@ const CompaniesPage = ({ useStorybookUrl = false }) => {
         )}
 
         {/* Organizations Section Header */}
-        <div className="mb-6 mt-12">
-          <h2 className="text-2xl font-semibold text-futarchyGray12 dark:text-white mb-6">
+        <div className="mb-6 mt-12 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-2xl font-semibold text-futarchyGray12 dark:text-white">
             Organizations
           </h2>
+          <Link
+            href="/markets/new"
+            className="inline-flex h-10 items-center justify-center rounded-md border border-futarchyGray6 px-4 text-sm font-medium text-futarchyGray12 hover:border-futarchyBlue9 hover:text-futarchyBlue10 dark:border-futarchyGray7 dark:text-white"
+          >
+            Create market
+          </Link>
         </div>
 
         {/* Organizations Table (Desktop) */}

--- a/src/components/futarchyFi/createMarket/CreateMarketFlow.jsx
+++ b/src/components/futarchyFi/createMarket/CreateMarketFlow.jsx
@@ -1,0 +1,249 @@
+import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  buildOneStepMarketPlan,
+  buildPermissionlessStackPlan,
+  createMarketWizardDefaults,
+  KNOWN_ORGANIZATIONS,
+} from '../../../features/marketCreation/marketCreationWorkflow';
+import RootLayout from '../../layout/RootLayout';
+import PageLayout from '../../layout/PageLayout';
+
+const panelClass = 'border border-futarchyGray6 dark:border-futarchyGray7 bg-white dark:bg-futarchyGray2 rounded-lg';
+const inputClass = 'w-full px-3 py-2 bg-futarchyGray2 dark:bg-futarchyGray3 border border-futarchyGray6 dark:border-futarchyGray7 rounded-md text-sm text-futarchyGray12 dark:text-white focus:outline-none focus:ring-2 focus:ring-futarchyBlue9';
+const labelClass = 'text-xs font-semibold uppercase tracking-wide text-futarchyGray10 dark:text-futarchyGray11';
+
+function formatDate(timestamp) {
+  if (!timestamp) return 'Not set';
+  return new Date(Number(timestamp) * 1000).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+}
+
+function StageList({ stages }) {
+  return (
+    <ol className="divide-y divide-futarchyGray5 dark:divide-futarchyGray7">
+      {stages.map((stage) => (
+        <li key={stage.id} className="grid gap-2 md:grid-cols-[48px_220px_1fr] px-4 py-3">
+          <div className="text-sm font-semibold text-futarchyBlue9">{String(stage.order).padStart(2, '0')}</div>
+          <div>
+            <div className="text-sm font-semibold text-futarchyGray12 dark:text-white">{stage.title}</div>
+            {stage.dependsOn?.length ? (
+              <div className="mt-1 text-xs text-futarchyGray10">After: {stage.dependsOn.join(', ')}</div>
+            ) : null}
+          </div>
+          <div>
+            <p className="text-sm text-futarchyGray11 dark:text-futarchyGray11">{stage.summary}</p>
+            {stage.requiredEvidence?.length ? (
+              <p className="mt-1 text-xs text-futarchyGray9">
+                Evidence: {stage.requiredEvidence.join(', ')}
+              </p>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function MetadataPreview({ metadata }) {
+  return (
+    <pre className="max-h-[420px] overflow-auto rounded-md bg-futarchyGray2 dark:bg-futarchyDarkGray3 border border-futarchyGray6 dark:border-futarchyGray7 p-4 text-xs text-futarchyGray12 dark:text-futarchyGray11">
+      {JSON.stringify(metadata, null, 2)}
+    </pre>
+  );
+}
+
+export default function CreateMarketFlow() {
+  const [organizationId, setOrganizationId] = useState('kleros');
+  const defaults = useMemo(
+    () => createMarketWizardDefaults({ organizationId }),
+    [organizationId]
+  );
+  const [form, setForm] = useState(defaults);
+
+  const selectedOrganization = KNOWN_ORGANIZATIONS[organizationId];
+  const marketPlan = useMemo(() => buildOneStepMarketPlan({ ...form, organizationId }), [form, organizationId]);
+  const permissionlessPlan = useMemo(() => buildPermissionlessStackPlan(), []);
+
+  const updateOrganization = (nextOrganizationId) => {
+    setOrganizationId(nextOrganizationId);
+    setForm(createMarketWizardDefaults({ organizationId: nextOrganizationId }));
+  };
+
+  const updateField = (field, value) => {
+    setForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const updateCloseDate = (value) => {
+    const nextTimestamp = Math.floor(new Date(value).getTime() / 1000);
+    setForm((previous) => ({
+      ...previous,
+      closeDateTimeLocal: value,
+      closeTimestamp: nextTimestamp,
+      twapStartTimestamp: nextTimestamp - (48 * 60 * 60),
+      startCandleUnix: nextTimestamp - (49 * 60 * 60),
+    }));
+  };
+
+  return (
+    <RootLayout headerConfig="app" footerConfig="main">
+      <PageLayout contentClassName="max-w-7xl">
+        <div className="py-8">
+          <div className="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-futarchyGray12 dark:text-white">Create Market</h1>
+              <p className="mt-2 max-w-3xl text-sm text-futarchyGray11 dark:text-futarchyGray11">
+                A single operational flow for organization setup, proposal metadata, market creation,
+                FLM liquidity, Snapshot linking, candle readiness, arbitrage setup, and publishing.
+              </p>
+            </div>
+            <Link
+              href="/companies"
+              className="inline-flex h-10 items-center justify-center rounded-md border border-futarchyGray6 px-4 text-sm font-medium text-futarchyGray12 dark:border-futarchyGray7 dark:text-white"
+            >
+              Companies
+            </Link>
+          </div>
+
+          <section className={`${panelClass} mb-6`}>
+            <div className="border-b border-futarchyGray6 px-4 py-3 dark:border-futarchyGray7">
+              <h2 className="text-lg font-semibold text-futarchyGray12 dark:text-white">Permissionless Chiado Stack</h2>
+              <p className="mt-1 text-sm text-futarchyGray11">
+                This is the target testnet lifecycle: any wallet creates an organization, it is listed
+                automatically, and the organization receives a default FLM for proposal liquidity.
+              </p>
+            </div>
+            <StageList stages={permissionlessPlan.stages} />
+          </section>
+
+          <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+            <section className={`${panelClass} p-4`}>
+              <h2 className="text-lg font-semibold text-futarchyGray12 dark:text-white">Market Defaults</h2>
+
+              <div className="mt-5 space-y-4">
+                <div>
+                  <label className={labelClass} htmlFor="organization">Organization</label>
+                  <select
+                    id="organization"
+                    className={`${inputClass} mt-1`}
+                    value={organizationId}
+                    onChange={(event) => updateOrganization(event.target.value)}
+                  >
+                    {Object.values(KNOWN_ORGANIZATIONS).map((org) => (
+                      <option key={org.id} value={org.id}>{org.name}</option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className={labelClass} htmlFor="proposalCode">Proposal Code</label>
+                  <input
+                    id="proposalCode"
+                    className={`${inputClass} mt-1`}
+                    value={form.proposalCode}
+                    onChange={(event) => updateField('proposalCode', event.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClass} htmlFor="displayTitle0">Display Title</label>
+                  <input
+                    id="displayTitle0"
+                    className={`${inputClass} mt-1`}
+                    value={form.displayTitle0}
+                    onChange={(event) => updateField('displayTitle0', event.target.value)}
+                  />
+                  <input
+                    aria-label="Display title event"
+                    className={`${inputClass} mt-2`}
+                    value={form.displayTitle1}
+                    onChange={(event) => updateField('displayTitle1', event.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClass} htmlFor="question">Resolution Question</label>
+                  <textarea
+                    id="question"
+                    className={`${inputClass} mt-1 min-h-[88px]`}
+                    value={form.question}
+                    onChange={(event) => updateField('question', event.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClass} htmlFor="snapshotId">Snapshot Proposal Hash</label>
+                  <input
+                    id="snapshotId"
+                    className={`${inputClass} mt-1 font-mono`}
+                    placeholder="0x..."
+                    value={form.snapshotId}
+                    onChange={(event) => updateField('snapshotId', event.target.value)}
+                  />
+                </div>
+
+                <div>
+                  <label className={labelClass} htmlFor="closeDate">Vote Close Time</label>
+                  <input
+                    id="closeDate"
+                    type="datetime-local"
+                    className={`${inputClass} mt-1`}
+                    value={form.closeDateTimeLocal}
+                    onChange={(event) => updateCloseDate(event.target.value)}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <div className={labelClass}>Company Token</div>
+                    <div className="mt-1 rounded-md border border-futarchyGray6 p-3 text-sm dark:border-futarchyGray7">
+                      <div className="font-semibold text-futarchyGray12 dark:text-white">{selectedOrganization.companyToken.symbol}</div>
+                      <div className="mt-1 break-all font-mono text-xs text-futarchyGray10">{selectedOrganization.companyToken.address}</div>
+                    </div>
+                  </div>
+                  <div>
+                    <div className={labelClass}>Currency Token</div>
+                    <div className="mt-1 rounded-md border border-futarchyGray6 p-3 text-sm dark:border-futarchyGray7">
+                      <div className="font-semibold text-futarchyGray12 dark:text-white">{selectedOrganization.currencyToken.symbol}</div>
+                      <div className="mt-1 break-all font-mono text-xs text-futarchyGray10">{selectedOrganization.currencyToken.address}</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className={`${panelClass}`}>
+              <div className="border-b border-futarchyGray6 px-4 py-3 dark:border-futarchyGray7">
+                <h2 className="text-lg font-semibold text-futarchyGray12 dark:text-white">One-Step Execution Plan</h2>
+                <div className="mt-2 grid gap-2 text-xs text-futarchyGray10 md:grid-cols-3">
+                  <span>Org: {marketPlan.values.organizationName}</span>
+                  <span>Close: {formatDate(marketPlan.values.closeTimestamp)}</span>
+                  <span>Liquidity: {marketPlan.values.initialLiquidityMode.toUpperCase()}</span>
+                </div>
+              </div>
+              <StageList stages={marketPlan.stages} />
+            </section>
+          </div>
+
+          <section className={`${panelClass} mt-6 p-4`}>
+            <div className="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-futarchyGray12 dark:text-white">Generated Metadata Draft</h2>
+                <p className="mt-1 text-sm text-futarchyGray11">
+                  This is the registry metadata shape the one-step flow will pass into the market
+                  creation and proposal metadata writes.
+                </p>
+              </div>
+              <Link
+                href={`/milestones?company_id=${selectedOrganization.organizationAddress}`}
+                className="inline-flex h-9 items-center justify-center rounded-md border border-futarchyGray6 px-3 text-sm text-futarchyGray12 dark:border-futarchyGray7 dark:text-white"
+              >
+                Open organization
+              </Link>
+            </div>
+            <MetadataPreview metadata={marketPlan.metadataDraft} />
+          </section>
+        </div>
+      </PageLayout>
+    </RootLayout>
+  );
+}

--- a/src/components/futarchyFi/createMarket/CreateMarketFlow.jsx
+++ b/src/components/futarchyFi/createMarket/CreateMarketFlow.jsx
@@ -44,6 +44,33 @@ function StageList({ stages }) {
   );
 }
 
+function ActionList({ actions }) {
+  return (
+    <ol className="divide-y divide-futarchyGray5 dark:divide-futarchyGray7">
+      {actions.map((action) => (
+        <li key={action.id} className="grid gap-2 px-4 py-3 md:grid-cols-[48px_270px_1fr]">
+          <div className="text-sm font-semibold text-futarchyBlue9">{String(action.order).padStart(2, '0')}</div>
+          <div>
+            <div className="break-words font-mono text-xs font-semibold text-futarchyGray12 dark:text-white">
+              {action.contract}.{action.method}
+            </div>
+            <div className="mt-1 text-xs uppercase text-futarchyGray9">Stage: {action.stageId}</div>
+            {action.dependsOn?.length ? (
+              <div className="mt-1 break-words text-xs text-futarchyGray10">After: {action.dependsOn.join(', ')}</div>
+            ) : null}
+          </div>
+          <div>
+            <p className="text-sm text-futarchyGray11 dark:text-futarchyGray11">{action.summary}</p>
+            {action.produces?.length ? (
+              <p className="mt-1 text-xs text-futarchyGray9">Produces: {action.produces.join(', ')}</p>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 function MetadataPreview({ metadata }) {
   return (
     <pre className="max-h-[420px] overflow-auto rounded-md bg-futarchyGray2 dark:bg-futarchyDarkGray3 border border-futarchyGray6 dark:border-futarchyGray7 p-4 text-xs text-futarchyGray12 dark:text-futarchyGray11">
@@ -113,6 +140,10 @@ export default function CreateMarketFlow() {
               </p>
             </div>
             <StageList stages={permissionlessPlan.stages} />
+            <div className="border-t border-futarchyGray6 px-4 py-3 dark:border-futarchyGray7">
+              <h3 className="text-sm font-semibold text-futarchyGray12 dark:text-white">Contract Actions</h3>
+            </div>
+            <ActionList actions={permissionlessPlan.contractActions} />
           </section>
 
           <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
@@ -221,6 +252,10 @@ export default function CreateMarketFlow() {
                 </div>
               </div>
               <StageList stages={marketPlan.stages} />
+              <div className="border-t border-futarchyGray6 px-4 py-3 dark:border-futarchyGray7">
+                <h3 className="text-sm font-semibold text-futarchyGray12 dark:text-white">Contract Actions</h3>
+              </div>
+              <ActionList actions={marketPlan.contractActions} />
             </section>
           </div>
 

--- a/src/features/marketCreation/marketCreationWorkflow.js
+++ b/src/features/marketCreation/marketCreationWorkflow.js
@@ -53,8 +53,10 @@ export const PERMISSIONLESS_TESTNET_DEFAULTS = {
   chainName: 'Gnosis Chiado',
   mode: 'permissionless',
   contracts: {
-    organizationCreator: '',
+    aggregatorFactory: '',
     permissionlessAggregator: '',
+    organizationImplementation: '',
+    proposalImplementation: '',
     futarchyFactory: '',
     liquidityManagerFactory: '',
     snapshotLinkRegistry: '',
@@ -122,27 +124,253 @@ export const PERMISSIONLESS_STACK_STAGES = [
   {
     id: 'deploy-stack',
     title: 'Deploy permissionless stack',
-    summary: 'Deploy creator, public aggregator, market factory, Snapshot linker, indexer hooks, and FLM factory on Chiado.',
+    summary: 'Deploy metadata implementations, public aggregator, market factory, Snapshot linker, indexer hooks, and FLM factory on Chiado.',
+  },
+  {
+    id: 'default-flm',
+    title: 'Create default FLM bundle',
+    summary: 'Create the proposal source, pool adapters, and default FLM bundle that will be attached to the organization.',
+    dependsOn: ['deploy-stack'],
   },
   {
     id: 'create-organization',
     title: 'Create organization',
-    summary: 'Any wallet can create organization metadata; the creator becomes organization owner.',
+    summary: 'Any wallet can create organization metadata with default FLM wiring; the creator becomes organization owner.',
+    dependsOn: ['default-flm'],
   },
   {
     id: 'list-organization',
     title: 'List organization',
     summary: 'Every created organization is added to the permissionless aggregator and appears in listings.',
-  },
-  {
-    id: 'default-flm',
-    title: 'Attach default FLM',
-    summary: 'Each organization gets a default FLM configured onchain at creation time.',
+    dependsOn: ['create-organization'],
   },
   {
     id: 'owner-proposal',
     title: 'Owner creates proposal',
     summary: 'The organization owner can create proposals and point the FLM at the official proposal.',
+    dependsOn: ['list-organization'],
+  },
+];
+
+export const CONTRACT_SOURCES = {
+  registry: {
+    repository: 'futarchy-fi/futarchy',
+    contracts: [
+      'FutarchyAggregatorFactory',
+      'FutarchyAggregatorsMetadata',
+      'FutarchyOrganizationMetadata',
+      'FutarchyProposalMetadata',
+    ],
+  },
+  liquidityManager: {
+    repository: 'futarchy-fi/futarchy-liquidity-manager',
+    contracts: [
+      'FutarchyLiquidityManagerFactory',
+      'FutarchyOfficialProposalSource',
+      'FutarchyLiquidityManager',
+    ],
+  },
+};
+
+export const PERMISSIONLESS_STACK_CONTRACT_ACTIONS = [
+  {
+    id: 'deploy-permissionless-registry',
+    stageId: 'deploy-stack',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy/script/deploy/DeployPermissionlessRegistry.s.sol',
+    contract: 'DeployPermissionlessRegistry',
+    method: 'run',
+    summary: 'Deploy aggregator, organization, and proposal metadata implementations plus their factories.',
+    produces: ['aggregatorFactory', 'permissionlessAggregator', 'organizationImplementation', 'proposalImplementation'],
+  },
+  {
+    id: 'create-default-flm-bundle',
+    stageId: 'default-flm',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy-liquidity-manager/src/factories/FutarchyLiquidityManagerFactory.sol',
+    contract: 'FutarchyLiquidityManagerFactory',
+    method: 'createLiquidityManager',
+    summary: 'Deploy proposal source, spot adapter, conditional adapter, and default organization FLM.',
+    produces: ['proposalSource', 'spotAdapter', 'conditionalAdapter', 'manager'],
+    inputs: ['CreateParams.owner', 'CreateParams.proposalManager', 'CreateParams.companyToken', 'CreateParams.officialProposer'],
+    dependsOn: ['deploy-permissionless-registry'],
+  },
+  {
+    id: 'create-and-list-organization',
+    stageId: 'create-organization',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy/src/registry/FutarchyAggregatorsMetadata.sol',
+    contract: 'FutarchyAggregatorsMetadata',
+    method: 'createAndAddOrganizationMetadataWithDefaultLiquidityManager',
+    summary: 'Create organization metadata, attach the FLM/proposal source, and add it to the aggregator in one call.',
+    produces: ['organizationMetadata'],
+    inputs: ['companyName', 'description', 'metadata', 'metadataURI', 'manager', 'proposalSource', 'liquidityManagerMetadataURI'],
+    dependsOn: ['create-default-flm-bundle'],
+  },
+  {
+    id: 'read-listed-organizations',
+    stageId: 'list-organization',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy/src/registry/FutarchyAggregatorsMetadata.sol',
+    contract: 'FutarchyAggregatorsMetadata',
+    method: 'getOrganizations',
+    summary: 'Read the aggregator list that backs the companies page.',
+    produces: ['listedOrganization'],
+    dependsOn: ['create-and-list-organization'],
+  },
+  {
+    id: 'owner-create-proposal-metadata',
+    stageId: 'owner-proposal',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy/src/registry/FutarchyOrganizationMetadata.sol',
+    contract: 'FutarchyOrganizationMetadata',
+    method: 'createAndAddProposalMetadata',
+    summary: 'Organization owner or editor writes proposal metadata after the futarchy proposal exists.',
+    produces: ['proposalMetadata'],
+    inputs: ['proposalAddress', 'displayNameQuestion', 'displayNameEvent', 'description', 'metadata', 'metadataURI'],
+    dependsOn: ['read-listed-organizations'],
+  },
+  {
+    id: 'owner-set-official-proposal',
+    stageId: 'owner-proposal',
+    chainId: CHIADO_CHAIN_ID,
+    source: 'futarchy-liquidity-manager/src/sources/FutarchyOfficialProposalSource.sol',
+    contract: 'FutarchyOfficialProposalSource',
+    method: 'setOfficialProposal',
+    summary: 'Point the default FLM proposal source at the active proposal once the proposal address is known.',
+    produces: ['officialProposal'],
+    inputs: ['proposalId', 'proposalAddress', 'creator'],
+    dependsOn: ['owner-create-proposal-metadata', 'create-default-flm-bundle'],
+  },
+];
+
+export const ONE_STEP_MARKET_CONTRACT_ACTIONS = [
+  {
+    id: 'publish-metadata-json',
+    stageId: 'metadata',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'interface/src/features/marketCreation/marketCreationWorkflow.js',
+    contract: 'MetadataPublisher',
+    method: 'publishProposalJson',
+    summary: 'Build and publish the registry metadata JSON, including Snapshot visibility fields.',
+    produces: ['metadataJson', 'metadataURI'],
+  },
+  {
+    id: 'create-futarchy-proposal',
+    stageId: 'market',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy/src/interfaces/IFutarchyFactory.sol',
+    contract: 'IFutarchyFactory',
+    method: 'createProposal',
+    summary: 'Create the futarchy proposal market using company token, currency token, bond, and opening time.',
+    produces: ['proposalAddress'],
+    inputs: ['CreateProposalParams.marketName', 'collateralToken1', 'collateralToken2', 'minBond', 'openingTime'],
+    dependsOn: ['publish-metadata-json'],
+  },
+  {
+    id: 'create-proposal-metadata',
+    stageId: 'metadata',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy/src/registry/FutarchyOrganizationMetadata.sol',
+    contract: 'FutarchyOrganizationMetadata',
+    method: 'createAndAddProposalMetadata',
+    summary: 'Store proposal metadata on the organization after the proposal address exists.',
+    produces: ['proposalMetadata'],
+    inputs: ['proposalAddress', 'displayNameQuestion', 'displayNameEvent', 'description', 'metadata', 'metadataURI'],
+    dependsOn: ['create-futarchy-proposal', 'publish-metadata-json'],
+  },
+  {
+    id: 'create-flm-bundle',
+    stageId: 'liquidity',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy-liquidity-manager/src/factories/FutarchyLiquidityManagerFactory.sol',
+    contract: 'FutarchyLiquidityManagerFactory',
+    method: 'createLiquidityManager',
+    summary: 'Create or reuse the organization FLM bundle for this token pair.',
+    produces: ['proposalSource', 'spotAdapter', 'conditionalAdapter', 'manager'],
+    inputs: ['CreateParams.organization', 'CreateParams.owner', 'CreateParams.companyToken', 'CreateParams.officialProposer'],
+    dependsOn: ['create-futarchy-proposal'],
+  },
+  {
+    id: 'store-default-flm',
+    stageId: 'liquidity',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy/src/registry/FutarchyOrganizationMetadata.sol',
+    contract: 'FutarchyOrganizationMetadata',
+    method: 'setDefaultLiquidityManager',
+    summary: 'Store the FLM and proposal source as the organization default used by market pages.',
+    produces: ['defaultLiquidityManager'],
+    inputs: ['manager', 'proposalSource', 'liquidityManagerMetadataURI'],
+    dependsOn: ['create-flm-bundle'],
+  },
+  {
+    id: 'set-official-proposal',
+    stageId: 'liquidity',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy-liquidity-manager/src/sources/FutarchyOfficialProposalSource.sol',
+    contract: 'FutarchyOfficialProposalSource',
+    method: 'setOfficialProposal',
+    summary: 'Point the FLM proposal source at the newly created proposal before public Snapshot routing.',
+    produces: ['officialProposal'],
+    inputs: ['proposalId', 'proposalAddress', 'creator'],
+    dependsOn: ['create-futarchy-proposal', 'create-flm-bundle'],
+  },
+  {
+    id: 'bootstrap-flm-liquidity',
+    stageId: 'liquidity',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'futarchy-liquidity-manager/src/core/FutarchyLiquidityManager.sol',
+    contract: 'FutarchyLiquidityManager',
+    method: 'initializeFromBootstrap',
+    summary: 'Seed spot liquidity through the FLM before Snapshot sends users to the market.',
+    produces: ['flmAddress', 'liquidityTxHash'],
+    inputs: ['companyAmount', 'spotAddData'],
+    dependsOn: ['store-default-flm', 'set-official-proposal'],
+  },
+  {
+    id: 'link-snapshot-proposal',
+    stageId: 'snapshot',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'snapshot metadata/link registry',
+    contract: 'SnapshotLinkRegistry',
+    method: 'linkSnapshotProposal',
+    summary: 'Link Snapshot after liquidity is present and proposal metadata has been written.',
+    produces: ['snapshotLinkRegistryTxHash'],
+    inputs: ['snapshotSpace', 'snapshotId', 'proposalAddress'],
+    dependsOn: ['bootstrap-flm-liquidity', 'create-proposal-metadata'],
+  },
+  {
+    id: 'verify-registry-and-candles',
+    stageId: 'indexing',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'interface indexers',
+    contract: 'CandleIndexer',
+    method: 'backfillMarket',
+    summary: 'Verify organization/proposal metadata, market candles, and spot price feeds before publish.',
+    produces: ['registryIndexed', 'candlesIndexed'],
+    dependsOn: ['bootstrap-flm-liquidity', 'create-proposal-metadata'],
+  },
+  {
+    id: 'configure-arbitrage',
+    stageId: 'arbitrage',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'arbitrage service',
+    contract: 'FutarchyArbitrageFactory',
+    method: 'configureMarket',
+    summary: 'Configure arb contracts and bot parameters for the YES/NO and spot pools.',
+    produces: ['arbitrageContract', 'botConfig'],
+    dependsOn: ['bootstrap-flm-liquidity'],
+  },
+  {
+    id: 'publish-company-market',
+    stageId: 'publish',
+    chainId: GNOSIS_CHAIN_ID,
+    source: 'interface company pages',
+    contract: 'CompanyMarketRegistry',
+    method: 'publish',
+    summary: 'Expose the market on the company page once Snapshot, candles, metadata, and liquidity are ready.',
+    produces: ['companyPageLink', 'marketUrl', 'flmUrl'],
+    dependsOn: ['link-snapshot-proposal', 'verify-registry-and-candles', 'configure-arbitrage'],
   },
 ];
 
@@ -243,8 +471,55 @@ export function buildMetadataDraft(input = {}) {
     flm: {
       mode: merged.initialLiquidityMode,
       address: merged.flmAddress || '',
+      proposalSource: merged.proposalSource || '',
       officialProposalAfterMarketCreation: true,
     },
+    snapshot: {
+      space: merged.snapshotSpace,
+      proposalId: merged.snapshotId,
+      linkAfterLiquidity: true,
+      visibilityMetadata: {
+        includeOnSnapshotWebsite: true,
+        linkedBy: 'SnapshotLinkRegistry.linkSnapshotProposal',
+      },
+    },
+    registry: {
+      organizationAddress: merged.organizationAddress,
+      proposalCode: merged.proposalCode,
+      proposalMetadataMethod: 'FutarchyOrganizationMetadata.createAndAddProposalMetadata',
+      defaultLiquidityManagerMethod: 'FutarchyOrganizationMetadata.setDefaultLiquidityManager',
+    },
+  };
+}
+
+export function buildContractActionPlan(actions, stages, values = {}) {
+  const stageOrders = new Map(stages.map((stage) => [stage.id, stage.order]));
+
+  return actions.map((action, index) => ({
+    ...action,
+    order: index + 1,
+    stageOrder: stageOrders.get(action.stageId) || index + 1,
+    chainId: action.chainId || values.chainId || GNOSIS_CHAIN_ID,
+    enabled: action.enabled !== false,
+  }));
+}
+
+export function validateContractActionDependencies(actions = []) {
+  const seen = new Set();
+  const missing = [];
+
+  actions.forEach((action) => {
+    action.dependsOn?.forEach((dependency) => {
+      if (!seen.has(dependency)) {
+        missing.push(`${action.id}:${dependency}`);
+      }
+    });
+    seen.add(action.id);
+  });
+
+  return {
+    ok: missing.length === 0,
+    missing,
   };
 }
 
@@ -255,15 +530,17 @@ export function buildOneStepMarketPlan(input = {}) {
   });
   const values = { ...defaults, ...input };
   const metadataDraft = buildMetadataDraft(values);
+  const stages = MARKET_CREATION_STAGES.map((stage, index) => ({
+    ...stage,
+    order: index + 1,
+    enabled: stage.id !== 'snapshot' || values.snapshotLinkAfterLiquidity,
+  }));
 
   return {
     values,
     metadataDraft,
-    stages: MARKET_CREATION_STAGES.map((stage, index) => ({
-      ...stage,
-      order: index + 1,
-      enabled: stage.id !== 'snapshot' || values.snapshotLinkAfterLiquidity,
-    })),
+    stages,
+    contractActions: buildContractActionPlan(ONE_STEP_MARKET_CONTRACT_ACTIONS, stages, values),
   };
 }
 
@@ -284,6 +561,14 @@ export function buildPermissionlessStackPlan(config = {}) {
       order: index + 1,
       includedByDefault: stage.id !== 'deploy-stack',
     })),
+    contractActions: buildContractActionPlan(
+      PERMISSIONLESS_STACK_CONTRACT_ACTIONS,
+      PERMISSIONLESS_STACK_STAGES.map((stage, index) => ({
+        ...stage,
+        order: index + 1,
+      })),
+      values
+    ),
   };
 }
 
@@ -308,6 +593,9 @@ export function validateOneStepMarketPlan(
   }
   if (!values.snapshotLinkAfterLiquidity) {
     errors.push('snapshotLinkAfterLiquidity');
+  }
+  if (!validateContractActionDependencies(plan?.contractActions || []).ok) {
+    errors.push('contractActions.dependencies');
   }
 
   return {

--- a/src/features/marketCreation/marketCreationWorkflow.js
+++ b/src/features/marketCreation/marketCreationWorkflow.js
@@ -1,0 +1,317 @@
+const DAY_SECONDS = 24 * 60 * 60;
+
+export const CHIADO_CHAIN_ID = 10200;
+export const GNOSIS_CHAIN_ID = 100;
+
+export const KNOWN_ORGANIZATIONS = {
+  gnosis: {
+    id: 'gnosis',
+    name: 'Gnosis DAO',
+    proposalPrefix: 'GIP',
+    snapshotSpace: 'gnosis.eth',
+    organizationAddress: '0x3Fd2e8E71f75eED4b5c507706c413E33e0661bBf',
+    companyToken: {
+      symbol: 'GNO',
+      address: '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb',
+      decimals: 18,
+    },
+    currencyToken: {
+      symbol: 'sDAI',
+      address: '0xaf204776c7245bF4147c2612BF6e5972Ee483701',
+      decimals: 18,
+    },
+    spotPrice: {
+      ticker: '0x8189c4c96826d016a99986394103dfa9ae41e7ee::0x89c80a4540a00b5270347e02e2e144c71da2eced-hour-500-xdai',
+      stableRate: '0x89c80a4540a00b5270347e02e2e144c71da2eced',
+    },
+  },
+  kleros: {
+    id: 'kleros',
+    name: 'Kleros DAO',
+    proposalPrefix: 'KIP',
+    snapshotSpace: 'kleros.eth',
+    organizationAddress: '0xaAB097ead5c2Db1Ca7b1E5034224A2118EDAbe36',
+    companyToken: {
+      symbol: 'PNK',
+      address: '0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3',
+      decimals: 18,
+    },
+    currencyToken: {
+      symbol: 'sDAI',
+      address: '0xaf204776c7245bF4147c2612BF6e5972Ee483701',
+      decimals: 18,
+    },
+    spotPrice: {
+      ticker: 'composite::0x2613cb099c12cecb1bd290fd0ef6833949374165+0x4c3b00293070073d71455f20fa9e5868cffd8678::0x89c80a4540a00b5270347e02e2e144c71da2eced-hour-500-xdai',
+      stableRate: '0x89c80a4540a00b5270347e02e2e144c71da2eced',
+    },
+  },
+};
+
+export const PERMISSIONLESS_TESTNET_DEFAULTS = {
+  chainId: CHIADO_CHAIN_ID,
+  chainName: 'Gnosis Chiado',
+  mode: 'permissionless',
+  contracts: {
+    organizationCreator: '',
+    permissionlessAggregator: '',
+    futarchyFactory: '',
+    liquidityManagerFactory: '',
+    snapshotLinkRegistry: '',
+    candleIndexer: '',
+    arbitrageFactory: '',
+  },
+};
+
+export const MARKET_CREATION_STAGES = [
+  {
+    id: 'organization',
+    title: 'Organization',
+    summary: 'Select an existing organization or create a permissionless testnet organization.',
+    requiredEvidence: ['organizationAddress', 'organizationOwner'],
+  },
+  {
+    id: 'metadata',
+    title: 'Metadata',
+    summary: 'Build proposal metadata, registry metadata, Snapshot reference, and display titles.',
+    requiredEvidence: ['metadataJson', 'closeTimestamp', 'snapshotId'],
+  },
+  {
+    id: 'market',
+    title: 'Futarchy Market',
+    summary: 'Create the market with company/currency tokens, Reality bond, opening time, and resolver defaults.',
+    requiredEvidence: ['proposalAddress', 'factoryTxHash'],
+  },
+  {
+    id: 'liquidity',
+    title: 'Liquidity and FLM',
+    summary: 'Create or reuse the organization FLM, add initial liquidity, and set the official proposal.',
+    requiredEvidence: ['flmAddress', 'liquidityTxHash', 'officialProposalSet'],
+  },
+  {
+    id: 'snapshot',
+    title: 'Snapshot Link',
+    summary: 'Link Snapshot only after liquidity exists, so Snapshot users never land on an empty market.',
+    requiredEvidence: ['snapshotLinkRegistryTxHash'],
+    dependsOn: ['liquidity'],
+  },
+  {
+    id: 'indexing',
+    title: 'Candles and Indexing',
+    summary: 'Kickstart pools and verify registry/candle indexers can read the market.',
+    requiredEvidence: ['registryIndexed', 'candlesIndexed'],
+    dependsOn: ['market', 'liquidity'],
+  },
+  {
+    id: 'arbitrage',
+    title: 'Arbitrage',
+    summary: 'Deploy or configure arbitrage contracts and bots that keep YES/NO pricing checked.',
+    requiredEvidence: ['arbitrageContract', 'botConfig'],
+    dependsOn: ['market', 'liquidity'],
+  },
+  {
+    id: 'publish',
+    title: 'Publish',
+    summary: 'Expose the market and FLM links on the company page after all checks pass.',
+    requiredEvidence: ['companyPageLink', 'marketUrl', 'flmUrl'],
+    dependsOn: ['snapshot', 'indexing'],
+  },
+];
+
+export const PERMISSIONLESS_STACK_STAGES = [
+  {
+    id: 'deploy-stack',
+    title: 'Deploy permissionless stack',
+    summary: 'Deploy creator, public aggregator, market factory, Snapshot linker, indexer hooks, and FLM factory on Chiado.',
+  },
+  {
+    id: 'create-organization',
+    title: 'Create organization',
+    summary: 'Any wallet can create organization metadata; the creator becomes organization owner.',
+  },
+  {
+    id: 'list-organization',
+    title: 'List organization',
+    summary: 'Every created organization is added to the permissionless aggregator and appears in listings.',
+  },
+  {
+    id: 'default-flm',
+    title: 'Attach default FLM',
+    summary: 'Each organization gets a default FLM configured onchain at creation time.',
+  },
+  {
+    id: 'owner-proposal',
+    title: 'Owner creates proposal',
+    summary: 'The organization owner can create proposals and point the FLM at the official proposal.',
+  },
+];
+
+export function addDaysUnix(nowSeconds, days) {
+  return nowSeconds + days * DAY_SECONDS;
+}
+
+export function toDateTimeLocal(timestampSeconds) {
+  return new Date(timestampSeconds * 1000).toISOString().slice(0, 16);
+}
+
+export function getOrganizationDefaults(organizationId = 'gnosis') {
+  return KNOWN_ORGANIZATIONS[organizationId] || KNOWN_ORGANIZATIONS.gnosis;
+}
+
+export function createMarketWizardDefaults({
+  organizationId = 'gnosis',
+  nowSeconds = Math.floor(Date.now() / 1000),
+} = {}) {
+  const organization = getOrganizationDefaults(organizationId);
+  const proposalNumber = organization.id === 'kleros' ? '90' : '151';
+  const closeTimestamp = addDaysUnix(nowSeconds, 7);
+  const twapStartTimestamp = closeTimestamp - (48 * 60 * 60);
+
+  return {
+    mode: 'existing-org',
+    organizationId: organization.id,
+    organizationAddress: organization.organizationAddress,
+    organizationName: organization.name,
+    proposalNumber,
+    proposalCode: `${organization.proposalPrefix}-${proposalNumber}`,
+    displayTitle0: `What will the impact on ${organization.companyToken.symbol} price be`,
+    displayTitle1: `if ${organization.proposalPrefix}-${proposalNumber} is passed?`,
+    question: `Will ${organization.proposalPrefix}-${proposalNumber} be passed by ${organization.name}?`,
+    description: `Resolves Yes if ${organization.proposalPrefix}-${proposalNumber} is passed by ${organization.name}; otherwise resolves No.`,
+    snapshotSpace: organization.snapshotSpace,
+    snapshotId: '',
+    companyToken: organization.companyToken,
+    currencyToken: organization.currencyToken,
+    closeTimestamp,
+    closeDateTimeLocal: toDateTimeLocal(closeTimestamp),
+    startCandleUnix: twapStartTimestamp - (60 * 60),
+    twapStartTimestamp,
+    twapDurationHours: 24,
+    minBondWei: '1000000000000000000',
+    eventProbability: 0.5,
+    initialLiquidityMode: 'flm',
+    initialLiquidityBudget: {
+      companyToken: '0.001',
+      currencyToken: '0.001',
+    },
+    spotPrice: organization.spotPrice,
+    snapshotLinkAfterLiquidity: true,
+    kickstartCandles: true,
+    deployArbitrage: true,
+  };
+}
+
+export function buildMetadataDraft(input = {}) {
+  const organization = getOrganizationDefaults(input.organizationId);
+  const defaults = createMarketWizardDefaults({
+    organizationId: organization.id,
+    nowSeconds: input.nowSeconds || Math.floor(Date.now() / 1000),
+  });
+  const merged = { ...defaults, ...input };
+
+  return {
+    chain: GNOSIS_CHAIN_ID,
+    proposalAddress: merged.proposalAddress || '',
+    organizationAddress: merged.organizationAddress,
+    snapshot_id: merged.snapshotId,
+    closeTimestamp: Number(merged.closeTimestamp),
+    startCandleUnix: Number(merged.startCandleUnix),
+    twapStartTimestamp: Number(merged.twapStartTimestamp),
+    twapDurationHours: Number(merged.twapDurationHours),
+    coingecko_ticker: merged.spotPrice?.ticker,
+    currency_stable_rate: merged.spotPrice?.stableRate,
+    currency_stable_symbol: 'xDAI',
+    visibility: 'public',
+    resolution_status: 'unresolved',
+    eventProbability: Number(merged.eventProbability),
+    display_title_0: merged.displayTitle0,
+    display_title_1: merged.displayTitle1,
+    companyTokens: {
+      base: {
+        tokenName: merged.companyToken.symbol,
+        tokenSymbol: merged.companyToken.symbol,
+        wrappedCollateralTokenAddress: merged.companyToken.address,
+      },
+    },
+    currencyTokens: {
+      base: {
+        tokenName: merged.currencyToken.symbol,
+        tokenSymbol: merged.currencyToken.symbol,
+        wrappedCollateralTokenAddress: merged.currencyToken.address,
+      },
+    },
+    flm: {
+      mode: merged.initialLiquidityMode,
+      address: merged.flmAddress || '',
+      officialProposalAfterMarketCreation: true,
+    },
+  };
+}
+
+export function buildOneStepMarketPlan(input = {}) {
+  const defaults = createMarketWizardDefaults({
+    organizationId: input.organizationId || 'gnosis',
+    nowSeconds: input.nowSeconds,
+  });
+  const values = { ...defaults, ...input };
+  const metadataDraft = buildMetadataDraft(values);
+
+  return {
+    values,
+    metadataDraft,
+    stages: MARKET_CREATION_STAGES.map((stage, index) => ({
+      ...stage,
+      order: index + 1,
+      enabled: stage.id !== 'snapshot' || values.snapshotLinkAfterLiquidity,
+    })),
+  };
+}
+
+export function buildPermissionlessStackPlan(config = {}) {
+  const values = {
+    ...PERMISSIONLESS_TESTNET_DEFAULTS,
+    ...config,
+    contracts: {
+      ...PERMISSIONLESS_TESTNET_DEFAULTS.contracts,
+      ...(config.contracts || {}),
+    },
+  };
+
+  return {
+    values,
+    stages: PERMISSIONLESS_STACK_STAGES.map((stage, index) => ({
+      ...stage,
+      order: index + 1,
+      includedByDefault: stage.id !== 'deploy-stack',
+    })),
+  };
+}
+
+export function validateOneStepMarketPlan(
+  plan,
+  { nowSeconds = Math.floor(Date.now() / 1000) } = {}
+) {
+  const errors = [];
+  const values = plan?.values || {};
+
+  if (!values.organizationAddress || !/^0x[a-fA-F0-9]{40}$/.test(values.organizationAddress)) {
+    errors.push('organizationAddress');
+  }
+  if (!values.companyToken?.address || !/^0x[a-fA-F0-9]{40}$/.test(values.companyToken.address)) {
+    errors.push('companyToken.address');
+  }
+  if (!values.currencyToken?.address || !/^0x[a-fA-F0-9]{40}$/.test(values.currencyToken.address)) {
+    errors.push('currencyToken.address');
+  }
+  if (!values.closeTimestamp || Number(values.closeTimestamp) <= nowSeconds) {
+    errors.push('closeTimestamp');
+  }
+  if (!values.snapshotLinkAfterLiquidity) {
+    errors.push('snapshotLinkAfterLiquidity');
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+  };
+}

--- a/src/pages/markets/new/index.jsx
+++ b/src/pages/markets/new/index.jsx
@@ -1,13 +1,17 @@
-"use client";
-
 import dynamic from 'next/dynamic';
 
-// Import MarketPage with no SSR to avoid document undefined errors
-const MarketPage = dynamic(
-  () => import("../../../components/futarchyFi/marketPage/page/MarketPage"),
-  { ssr: false }
+const CreateMarketFlow = dynamic(
+  () => import('../../../components/futarchyFi/createMarket/CreateMarketFlow'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-futarchyDarkGray2">
+        <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-futarchyLavender" />
+      </div>
+    ),
+  }
 );
 
 export default function NewMarketPage() {
-  return <MarketPage />;
-} 
+  return <CreateMarketFlow />;
+}


### PR DESCRIPTION
## What changed
- Adds a deterministic market creation workflow model for Gnosis/Kleros defaults, Snapshot-after-liquidity ordering, FLM defaults, candle/indexer readiness, arbitrage setup, and publish steps.
- Wires the planner to concrete registry and FLM action descriptors: `IFutarchyFactory.createProposal`, `FutarchyLiquidityManagerFactory.createLiquidityManager`, `FutarchyOrganizationMetadata.createAndAddProposalMetadata`, `FutarchyOrganizationMetadata.setDefaultLiquidityManager`, and `FutarchyOfficialProposalSource.setOfficialProposal`.
- Replaces `/markets/new` with a guided Create Market UI and adds a Companies page entry point.
- Adds auto-qa coverage for KIP/GIP defaults, metadata shape, permissionless Chiado lifecycle, registry/FLM dependency order, and Snapshot-after-liquidity ordering.

## Validation
- `npx eslint src/features/marketCreation/marketCreationWorkflow.js src/components/futarchyFi/createMarket/CreateMarketFlow.jsx src/components/futarchyFi/companyList/page/CompaniesPage.jsx src/pages/markets/new/index.jsx auto-qa/tests/market-creation-workflow.test.mjs`
- `node --test auto-qa/tests/market-creation-workflow.test.mjs` (8 tests)
- `npm run auto-qa:test -- --test-name-pattern "market creation|Kleros|Gnosis|permissionless|Snapshot|FLM factory|registry"` (npm forwards this to the full unit suite; 685 tests passed)
- `curl -I http://127.0.0.1:3001/markets/new`
- `curl -I http://127.0.0.1:3001/companies`

## Notes
Full `npm run lint` is still blocked by existing repo-wide lint failures outside this branch, including `src/app/new-design/_lib/mockData.js`, `src/components/common/Header.jsx`, and several pre-existing hook/display-name/no-unescaped-entities errors.