### PR TITLE
[codex] Fix create market static export

### DIFF
--- a/src/pages/markets/new/index.jsx
+++ b/src/pages/markets/new/index.jsx
@@ -1,16 +1,4 @@
-import dynamic from 'next/dynamic';
-
-const CreateMarketFlow = dynamic(
-  () => import('../../../components/futarchyFi/createMarket/CreateMarketFlow'),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-futarchyDarkGray2">
-        <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-futarchyLavender" />
-      </div>
-    ),
-  }
-);
+import CreateMarketFlow from '../../../components/futarchyFi/createMarket/CreateMarketFlow';
 
 export default function NewMarketPage() {
   return <CreateMarketFlow />;


### PR DESCRIPTION
## What changed
- Replaces the no-SSR dynamic import on `/markets/new` with a static import of `CreateMarketFlow`.
- This makes `next export` include the create-market UI in the generated page bundle instead of serving an empty shell that depends on async chunks that are currently 404ing in production.

## Why
After PR #77 was merged, `https://futarchy.fi/markets/new` returned 200 but the static HTML was an empty Next shell and its dynamic chunks returned 404. The page route existed, but the Create Market UI was not actually usable live.

## Validation
- `npx eslint src/pages/markets/new/index.jsx src/components/futarchyFi/createMarket/CreateMarketFlow.jsx src/features/marketCreation/marketCreationWorkflow.js auto-qa/tests/market-creation-workflow.test.mjs`
- `node --test auto-qa/tests/market-creation-workflow.test.mjs` (8 tests)
- `npm run build`
- Verified `out/markets/new.html` and `out/_next/static/chunks/pages/markets/new-*.js` contain `Create Market`, `Contract Actions`, `FutarchyLiquidityManagerFactory`, and `SnapshotLinkRegistry`.

## Current production before this fix
- `https://futarchy.fi/markets/new` returns 200 but serves an empty shell.
- `https://futarchy.fi/_next/static/chunks/2872-132f9eb21ff3b203.js` returns 404.
- `https://futarchy.fi/_next/static/chunks/4986-71e8163c575a3e1a.js` returns 404.