### PR TITLE
[codex] Run live auto-qa weekly

### DIFF
--- a/.github/workflows/auto-qa-live.yml
+++ b/.github/workflows/auto-qa-live.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: 'https://api.futarchy.fi'
   schedule:
-    - cron: '17 4 * * *'
+    - cron: '17 4 * * 1'
 
 jobs:
   live:

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/auto-qa.yml'
+      - '.github/workflows/auto-qa-live.yml'
       - 'auto-qa/**'
       - 'package.json'
       - 'src/utils/proposalLifecycle.js'
@@ -12,6 +13,7 @@ on:
       - main
     paths:
       - '.github/workflows/auto-qa.yml'
+      - '.github/workflows/auto-qa-live.yml'
       - 'auto-qa/**'
       - 'package.json'
       - 'src/utils/proposalLifecycle.js'


### PR DESCRIPTION
## Summary

- reduces the scheduled `auto-qa live` workflow from daily to weekly
- keeps the existing 04:17 UTC runtime, now on Mondays
- adds `.github/workflows/auto-qa-live.yml` to the deterministic `auto-qa` workflow path filters so PRs that edit the live workflow still receive a CI check

## Why

Daily live endpoint checks are more noise than value for this repo. Weekly still catches API drift while avoiding constant background runs.

## Validation

- `npm run auto-qa:test:unit` — 691 pass
- `git diff --check`
