### PR TITLE
Fix TWAP inversion (Kleros markets) + redeem visibility for on-chain-resolved markets

### DIFF
--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -74,7 +74,8 @@ const subgraphPoolFetcher = createSubgraphPoolFetcher();
 
 const GNOSIS_DEFAULT_RPC = process.env.NEXT_PUBLIC_GNOSIS_RPC || 'https://rpc.gnosischain.com';
 const ALGEBRA_TWAP_ABI = [
-  "function getTimepoints(uint32[] secondsAgos) external view returns (int56[] tickCumulatives, uint160[] secondsPerLiquidityCumulatives, uint112[] volatilityCumulatives, uint256[] volumePerAvgLiquiditys)"
+  "function getTimepoints(uint32[] secondsAgos) external view returns (int56[] tickCumulatives, uint160[] secondsPerLiquidityCumulatives, uint112[] volatilityCumulatives, uint256[] volumePerAvgLiquiditys)",
+  "function token0() external view returns (address)"
 ];
 const DEFAULT_TWAP_DESCRIPTION = "The Futarchy Test is considered passed if the time-weighted average price (TWAP) of the \u201cpass\u201d (yes) outcome over the final 24 hours of the Issuance KIP\u2019s voting period is greater than or equal to that of the \u201cfail\u201d (no) outcome. If not, the proposal fails the futarchy test, regardless of the Kleros DAO vote result.";
 const TWAP_REFRESH_INTERVAL_MS = 30000; // refresh every 30 seconds while active
@@ -512,7 +513,9 @@ const TwapCountdown = ({
   yesPoolConfig,
   noPoolConfig,
   invertTwapPoolYes = false,
-  invertTwapPoolNo = false
+  invertTwapPoolNo = false,
+  yesCompanyTokenAddress = null,
+  noCompanyTokenAddress = null
 }) => {
   const [timeRemaining, setTimeRemaining] = useState(null);
   const [timeUntilStart, setTimeUntilStart] = useState(null);
@@ -526,6 +529,7 @@ const TwapCountdown = ({
   const [twapError, setTwapError] = useState(null);
   const [lastTwapUpdate, setLastTwapUpdate] = useState(null);
   const providerRef = useRef(null);
+  const poolToken0CacheRef = useRef({});
 
   const twapDurationSeconds = useMemo(() => Math.max(1, Math.floor(twapDurationHours * 60 * 60)), [twapDurationHours]);
 
@@ -536,7 +540,7 @@ const TwapCountdown = ({
     return providerRef.current;
   }, []);
 
-  const fetchPoolTwap = useCallback(async (poolConfig, secondsAgoStart, shouldInvert = null, secondsAgoEnd = 0) => {
+  const fetchPoolTwap = useCallback(async (poolConfig, secondsAgoStart, shouldInvert = null, secondsAgoEnd = 0, companyTokenAddress = null) => {
     if (!poolConfig?.address) {
       throw new Error('Missing pool address');
     }
@@ -556,16 +560,48 @@ const TwapCountdown = ({
       throw new Error('Invalid price data');
     }
 
-    // Priority: explicit inversion flag from metadata > tokenCompanySlot from pool config
+    // Authoritative inversion check: read token0 from the pool and compare it to the
+    // conditional company token. Raw pool price = 1.0001^tick = token1/token0, so when
+    // the company token is token0 the raw price is already currency-per-company and
+    // must NOT be inverted. Metadata flags have been wrong before (Kleros KIP markets
+    // shipped invertTwapPoolYes/No=true while PNK was token0), so on-chain token order
+    // wins whenever we can determine it.
+    let onChainInvert = null;
+    if (companyTokenAddress) {
+      try {
+        const poolKey = poolConfig.address.toLowerCase();
+        let token0 = poolToken0CacheRef.current[poolKey];
+        if (!token0) {
+          token0 = (await poolContract.token0()).toLowerCase();
+          poolToken0CacheRef.current[poolKey] = token0;
+        }
+        onChainInvert = token0 !== companyTokenAddress.toLowerCase();
+      } catch (err) {
+        console.warn('[TWAP] token0() read failed, falling back to configured inversion:', err?.message);
+      }
+    }
+
+    // Priority: on-chain token order > explicit inversion flag from metadata > tokenCompanySlot from pool config
     // shouldInvert is null when not set, so we can distinguish between "not set" and "set to false"
-    const useInversion = shouldInvert !== null
-      ? shouldInvert
-      : (typeof poolConfig.tokenCompanySlot === 'number' && poolConfig.tokenCompanySlot === 1);
+    const useInversion = onChainInvert !== null
+      ? onChainInvert
+      : (shouldInvert !== null
+        ? shouldInvert
+        : (typeof poolConfig.tokenCompanySlot === 'number' && poolConfig.tokenCompanySlot === 1));
+
+    if (onChainInvert !== null && shouldInvert !== null && onChainInvert !== shouldInvert) {
+      console.warn('[TWAP] Metadata inversion flag contradicts on-chain token order; using on-chain value', {
+        pool: poolConfig.address,
+        metadataInvert: shouldInvert,
+        onChainInvert
+      });
+    }
 
     console.log('[TWAP] fetchPoolTwap:', {
       pool: poolConfig.address?.slice(0, 10),
       rawPrice: rawPrice.toFixed(4),
       shouldInvert,
+      onChainInvert,
       tokenCompanySlot: poolConfig.tokenCompanySlot,
       useInversion
     });
@@ -636,8 +672,8 @@ const TwapCountdown = ({
         const secondsAgoEnd = hasEnded ? Math.max(0, now - twapEndTimestamp) : 0;
 
         const [yesPrice, noPrice] = await Promise.all([
-          fetchPoolTwap(yesPoolConfig, secondsAgoStart, invertTwapPoolYes, secondsAgoEnd),
-          fetchPoolTwap(noPoolConfig, secondsAgoStart, invertTwapPoolNo, secondsAgoEnd)
+          fetchPoolTwap(yesPoolConfig, secondsAgoStart, invertTwapPoolYes, secondsAgoEnd, yesCompanyTokenAddress),
+          fetchPoolTwap(noPoolConfig, secondsAgoStart, invertTwapPoolNo, secondsAgoEnd, noCompanyTokenAddress)
         ]);
 
         if (cancelled) return;
@@ -669,7 +705,7 @@ const TwapCountdown = ({
       cancelled = true;
       if (intervalId) clearInterval(intervalId);
     };
-  }, [isActive, hasEnded, twapStartTimestamp, twapDurationSeconds, yesPoolConfig, noPoolConfig, invertTwapPoolYes, invertTwapPoolNo, fetchPoolTwap]);
+  }, [isActive, hasEnded, twapStartTimestamp, twapDurationSeconds, yesPoolConfig, noPoolConfig, invertTwapPoolYes, invertTwapPoolNo, yesCompanyTokenAddress, noCompanyTokenAddress, fetchPoolTwap]);
 
   const { leaderboardText, percentDiff, leaderTheme } = useMemo(() => {
     if (twapResults.yes === null || twapResults.no === null) return { leaderboardText: null, percentDiff: null, leaderTheme: 'neutral' };
@@ -5086,6 +5122,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
                 noPoolConfig={config.POOL_CONFIG_NO}
                 invertTwapPoolYes={config.marketInfo.invertTwapPoolYes || false}
                 invertTwapPoolNo={config.marketInfo.invertTwapPoolNo || config.marketInfo.invertTwapPoolNO || false}
+                yesCompanyTokenAddress={config.metadata?.companyTokens?.yes?.wrappedCollateralTokenAddress || null}
+                noCompanyTokenAddress={config.metadata?.companyTokens?.no?.wrappedCollateralTokenAddress || null}
               />
             )}
           </div>

--- a/src/hooks/useContractConfig.js
+++ b/src/hooks/useContractConfig.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { ethers } from 'ethers';
 import { createClient } from '@supabase/supabase-js';
 import { PRECISION_CONFIG } from '../components/futarchyFi/marketPage/constants/contracts';
 import { fetchMarketEventData, parseContractSource } from '../adapters/subgraphConfigAdapter';
@@ -8,6 +9,54 @@ import { fetchProposalMetadataFromRegistry, extractChainFromMetadata, extractSpo
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 const supabase = createClient(supabaseUrl, supabaseKey);
+
+// Public RPCs for the on-chain resolution fallback check
+const RESOLUTION_RPC_BY_CHAIN = {
+  1: 'https://eth.llamarpc.com',
+  100: process.env.NEXT_PUBLIC_GNOSIS_RPC || 'https://rpc.gnosischain.com'
+};
+
+/**
+ * Check resolution directly on-chain via ConditionalTokens payouts.
+ * Registry metadata can lag behind the actual on-chain resolution (e.g. Kleros KIP-88
+ * resolved on-chain but its metadata was never updated with resolution_status),
+ * which hid the Redeem tab. payoutDenominator > 0 is the authoritative signal that
+ * redemption is possible.
+ * @param {string} proposalAddress - FutarchyProposal contract address
+ * @param {string} conditionalTokensAddress - ConditionalTokens contract address
+ * @param {number|string} chainId - Chain the proposal lives on
+ * @returns {Promise<{resolved: boolean, outcome: string|null}|null>} null when the check fails
+ */
+async function fetchOnChainResolution(proposalAddress, conditionalTokensAddress, chainId) {
+  try {
+    const rpcUrl = RESOLUTION_RPC_BY_CHAIN[Number(chainId)] || RESOLUTION_RPC_BY_CHAIN[100];
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    const proposal = new ethers.Contract(
+      proposalAddress,
+      ['function conditionId() view returns (bytes32)'],
+      provider
+    );
+    const conditionId = await proposal.conditionId();
+    const conditionalTokens = new ethers.Contract(
+      conditionalTokensAddress,
+      [
+        'function payoutDenominator(bytes32) view returns (uint256)',
+        'function payoutNumerators(bytes32, uint256) view returns (uint256)'
+      ],
+      provider
+    );
+    const denominator = await conditionalTokens.payoutDenominator(conditionId);
+    if (denominator.isZero()) {
+      return { resolved: false, outcome: null };
+    }
+    // Outcome slot 0 = Yes, slot 1 = No for futarchy proposals
+    const yesNumerator = await conditionalTokens.payoutNumerators(conditionId, 0);
+    return { resolved: true, outcome: yesNumerator.gt(0) ? 'Yes' : 'No' };
+  } catch (error) {
+    console.warn('[Config] On-chain resolution check failed:', error?.message);
+    return null;
+  }
+}
 
 /**
  * Hook to fetch and manage contract configuration data from Supabase
@@ -283,6 +332,25 @@ export const useContractConfig = (proposalId, forceTestPools = false) => {
           console.log('🎯 Using proposal-specific base pool override:', proposalSpecificBasePool, 'for proposal:', extractedProposalId);
         }
 
+        // Resolution status: prefer metadata, but fall back to the on-chain
+        // ConditionalTokens payout state when metadata says unresolved/missing.
+        const metadataResolved = (data.resolution_outcome !== null && data.resolution_outcome !== undefined)
+          || data.resolution_status === 'resolved'
+          || data._registryMetadata?.resolution_status === 'resolved'
+          || (data._registryMetadata?.resolution_outcome !== null && data._registryMetadata?.resolution_outcome !== undefined);
+
+        let onChainResolution = null;
+        if (!metadataResolved && metadata?.contractInfos?.conditionalTokens) {
+          onChainResolution = await fetchOnChainResolution(
+            extractedProposalId,
+            metadata.contractInfos.conditionalTokens,
+            metadata?.chain || 100
+          );
+          if (onChainResolution?.resolved) {
+            console.log('[Config] Market resolved on-chain but not in metadata; enabling redemption UI', onChainResolution);
+          }
+        }
+
         // Transform API data into the format needed by the application
         const transformedConfig = {
           // Proposal/Market identification (these are the same thing)
@@ -491,13 +559,13 @@ export const useContractConfig = (proposalId, forceTestPools = false) => {
             // Include question link from metadata (check both nested and direct paths)
             questionLink: metadata?.metadata?.question_link || metadata?.questionLink || null,
             // Add resolved status - only resolved if there's an actual outcome or resolution_status indicates completion
-            // Fall back to _registryMetadata for resolution fields (market subgraph doesn't have these)
-            resolved: (data.resolution_outcome !== null && data.resolution_outcome !== undefined)
-              || data.resolution_status === 'resolved'
-              || data._registryMetadata?.resolution_status === 'resolved'
-              || (data._registryMetadata?.resolution_outcome !== null && data._registryMetadata?.resolution_outcome !== undefined),
-            resolutionStatus: data.resolution_status || data._registryMetadata?.resolution_status || null,
-            finalOutcome: data.resolution_outcome || data._registryMetadata?.resolution_outcome || metadata?.finalOutcome || null,
+            // Fall back to _registryMetadata for resolution fields (market subgraph doesn't have these),
+            // then to the on-chain ConditionalTokens payout state (metadata can lag behind resolution)
+            resolved: metadataResolved || onChainResolution?.resolved === true,
+            resolutionStatus: data.resolution_status || data._registryMetadata?.resolution_status
+              || (onChainResolution?.resolved ? 'resolved' : null),
+            finalOutcome: data.resolution_outcome || data._registryMetadata?.resolution_outcome || metadata?.finalOutcome
+              || onChainResolution?.outcome || null,
             // TWAP configuration (prioritize Registry metadata, then direct metadata)
             twapStartTimestamp: data._registryMetadata?.twapStartTimestamp || metadata?.twapStartTimestamp || null,
             twapDurationHours: data._registryMetadata?.twapDurationHours || metadata?.twapDurationHours || 24,


### PR DESCRIPTION
Two live partner-reported bugs (Clément, Kleros):

**TWAP inverted since Jun 3 (outcome-flipping).** Registry metadata for KIP-88/KIP-90 ships `invertTwapPoolYes/No: true`, but on-chain both conditional pools have the company token as token0, so the raw tick price is already sDAI-per-PNK. The TWAP widget applied the metadata flag and displayed the reciprocal, flipping which outcome looks ahead (KIP-90 real window: YES shown 148.59 vs actual 0.00673; NO 147.14 vs 0.00680 — displayed leader was wrong). Fix: `fetchPoolTwap` reads `pool.token0()` and compares against the conditional company token; on-chain order is authoritative, metadata is fallback, console warning on disagreement. Chart/candles layer verified correct (this is why the Jun 3 candles fix didn't help). Healthy markets (GNO) verified unaffected.

**Redeem not showing.** Redeem tab gated only on registry `resolution_status`; KIP-88 resolved on-chain Jun 5 (`payoutDenominator=1`, numerators `[1,0]`) but metadata was never updated. Fix: `fetchOnChainResolution()` fallback via proposal `conditionId()` → ConditionalTokens payouts, used only when metadata says unresolved. Verified live: KIP-88 → {resolved, Yes}; KIP-90 → unresolved (no false positive).

`npm run build` passes. Optional follow-up for the metadata owner: correct the two ProposalMetadata entries; UI no longer depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)