### PR TITLE
Remove dead Supabase dependency + stale Blast RPC entry

### DIFF
--- a/src/app/new-design/_lib/mockData.js
+++ b/src/app/new-design/_lib/mockData.js
@@ -136,7 +136,7 @@ export const MOCK_MARKETS = [
             "futarchyAdapter": "0x7495a583ba85875d59407781b4958ED6e0E1228f",
             "proposalAddress": "0xa28614aa999117C555757D56A8178F271C24d7BA",
             "twapDescription": "The Gnosis DAO Futarchy serves to advise delegates and community members on voting decisions, but the results are non-binding.",
-            "background_image": "https://nvhqdqtlsdboctqjcelq.supabase.co/storage/v1/object/public/market-images/market-backgrounds/1759351073623_0epecp.webp",
+            "background_image": null,
             "eventProbability": 0.5,
             "prediction_pools": {
                 "no": {
@@ -287,7 +287,7 @@ export const MOCK_MARKETS = [
             "display_title_1": "if its price is >= 130 sDAI?",
             "futarchyAdapter": "0x7495a583ba85875d59407781b4958ED6e0E1228f",
             "proposalAddress": "0x7e9Fc0C3d6C1619d4914556ad2dEe6051Ce68418",
-            "background_image": "https://nvhqdqtlsdboctqjcelq.supabase.co/storage/v1/object/public/market-images/market-backgrounds/1759351073623_0epecp.webp",
+            "background_image": null,
             "eventProbability": 0.25,
             "prediction_pools": {
                 "no": {

--- a/src/app/new-design/page.jsx
+++ b/src/app/new-design/page.jsx
@@ -2,15 +2,9 @@
 
 import React, { useState, useEffect } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import { createClient } from '@supabase/supabase-js';
 import { MOCK_MARKETS } from './_lib/mockData';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function NewDesignPage() {
   const [markets, setMarkets] = useState([]);
@@ -18,36 +12,10 @@ export default function NewDesignPage() {
   const [filter, setFilter] = useState('all');
 
   useEffect(() => {
-    async function fetchMarkets() {
-      try {
-        setLoading(true);
-        // Attempt to fetch from Supabase
-        const { data, error } = await supabase
-          .from('market_events') // Assuming table name based on context, usually 'markets' or 'proposals'
-          .select('*')
-          .limit(20);
-
-        if (error || !data || data.length === 0) {
-          console.warn("Supabase fetch failed or empty, using mock data:", error);
-          setMarkets(MOCK_MARKETS);
-        } else {
-            // Map supabase data to match structure if needed, or just use it
-            // For now, mixing in mock data if fetch returns very few to ensure UI looks good
-            if (data.length < 5) {
-                 setMarkets([...data, ...MOCK_MARKETS]);
-            } else {
-                 setMarkets(data);
-            }
-        }
-      } catch (err) {
-        console.error("Error fetching markets:", err);
-        setMarkets(MOCK_MARKETS);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchMarkets();
+    // The Supabase market_events backend is permanently gone; this design
+    // prototype renders from local mock data only.
+    setMarkets(MOCK_MARKETS);
+    setLoading(false);
   }, []);
 
   const filteredMarkets = markets.filter(m => {

--- a/src/components/chart/TripleChart.jsx
+++ b/src/components/chart/TripleChart.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { createChart, LineSeries } from 'lightweight-charts';
-import { createClient } from '@supabase/supabase-js';
 import { PRECISION_CONFIG } from '../futarchyFi/marketPage/constants/contracts';
 
 const computeRightOffset = (...seriesList) => {
@@ -19,9 +18,10 @@ const DEFAULT_BASE_POOL = '0xd1d7fa8871d84d0e77020fc28b7cd5718c446522';
 const IMPACT_POSITIVE_COLOR = '#00A89D'; // futarchyTeal7
 const IMPACT_NEGATIVE_COLOR = '#ED91B2'; // futarchyCrimson7
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''; // Use the public anon key
-const supabase = createClient(supabaseUrl, supabaseKey);
+// The Supabase candles backend is permanently gone; the chart renders from
+// prop data only. `supabase` is a stub so the (disabled) legacy code paths
+// below never crash if re-enabled by mistake.
+const supabase = null;
 
 const INTERVAL_OPTIONS = [
   { label: '1 Minute', value: '60000' },
@@ -39,8 +39,6 @@ const TripleChart = ({
   sdaiRate = null,
   isLoadingRate = false,
   rateError = null,
-  usingSupabaseRealtime = true,
-  useBaseFromSupabase = true, // <-- NEW FLAG
   yesPoolAddress = DEFAULT_YES_POOL,
   noPoolAddress = DEFAULT_NO_POOL,
   basePoolAddress = DEFAULT_BASE_POOL,
@@ -49,6 +47,11 @@ const TripleChart = ({
   chartFilters = { spot: true, yes: true, no: true, impact: false }, // Spot price shown as semi-transparent dashed line
   cropSpot = true, // Only show spot data points that have corresponding YES/NO data at the same timestamp
 }) => {
+  // Supabase realtime candle fetching is permanently disabled (backend gone);
+  // these flags stay hardcoded off so the chart only renders prop data.
+  const usingSupabaseRealtime = false;
+  const useBaseFromSupabase = false;
+
   // Get dynamic pool addresses from config - PRIORITIZE CONDITIONAL POOLS
   // POOL_CONFIG_YES/NO are mapped to conditional_pools in useContractConfig (the prediction market pools)
   // PREDICTION_POOLS are fallback pools if conditional pools not available

--- a/src/components/dynamicImageFolder/DynamicShareCard.jsx
+++ b/src/components/dynamicImageFolder/DynamicShareCard.jsx
@@ -28,79 +28,9 @@ const DynamicShareCard = ({ isOpen, onClose }) => {
     const [isAutoCycling, setIsAutoCycling] = useState(false);
     const [exportCounter, setExportCounter] = useState(0);
 
-    // Fetch companies on mount
-    useEffect(() => {
-        const fetchCompanies = async () => {
-            try {
-                const response = await fetch(
-                    `https://nvhqdqtlsdboctqjcelq.supabase.co/rest/v1/company?select=*&order=name.asc`,
-                    {
-                        headers: {
-                            'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
-                            'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}`
-                        }
-                    }
-                );
-
-                if (!response.ok) throw new Error('Failed to fetch companies');
-
-                const data = await response.json();
-                setCompanies(data);
-                if (data.length > 0) {
-                    setSelectedCompany(data[0]);
-                }
-            } catch (err) {
-                console.error('Error fetching companies:', err);
-                setError('Failed to load companies');
-            }
-        };
-
-        if (isOpen) { // Only fetch when open or on mount
-            fetchCompanies();
-        }
-    }, [isOpen]);
-
-    // Fetch markets when company changes
-    useEffect(() => {
-        if (selectedCompany) {
-            setLoading(true);
-            setError(null);
-            setSelectedMarket(null);
-
-            const fetchMarkets = async () => {
-                try {
-                    const response = await fetch(
-                        `https://nvhqdqtlsdboctqjcelq.supabase.co/rest/v1/market_event?select=*&company_id=eq.${selectedCompany.id}&order=created_at.desc`,
-                        {
-                            headers: {
-                                'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
-                                'Authorization': `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}`
-                            }
-                        }
-                    );
-
-                    if (!response.ok) {
-                        throw new Error('Failed to fetch markets');
-                    }
-
-                    const data = await response.json();
-                    setMarkets(data);
-
-                    // Auto-select first market if available
-                    if (data.length > 0) {
-                        setSelectedMarket(data[0]);
-                        setCurrentMarketIndex(0);
-                    }
-                } catch (err) {
-                    setError(err.message);
-                } finally {
-                    setLoading(false);
-                }
-            };
-
-            fetchMarkets();
-        }
-    }, [selectedCompany]);
+    // The Supabase company/market_event backend that used to feed these dropdowns
+    // is permanently gone. The card degrades to its empty state ("No markets
+    // available") until a replacement data source is wired up.
 
     // Auto-cycling functionality
     useEffect(() => {

--- a/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
+++ b/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
@@ -450,7 +450,7 @@ const HighlightCard = ({
                 ? 'bg-green-500/20 text-green-400 border border-green-500/30'
                 : 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
                 }`}>
-                {priceSource === 'subgraph' ? '📊 Subgraph' : '💾 Supabase'}
+                {priceSource === 'subgraph' ? '📊 Subgraph' : '📊 Subgraph (per-pool)'}
               </span>
               {chainId && <ChainBadge chainId={chainId} size="sm" />}
             </div>

--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, memo, useState, useCallback, useMemo } from "react";
 import { useSearchParams } from 'next/navigation';
-import { createClient } from '@supabase/supabase-js';
 import Image from "next/image";
 import RootLayout from "../../../components/layout/RootLayout";
 import { ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS } from '../../../config/featureFlags';
@@ -63,11 +62,6 @@ import { createSubgraphPoolFetcher } from "../../../utils/SubgraphPoolFetcher";
 //lets import from contract.js 
 import { UNISWAP_V3_POOL_ABI } from "./constants/contracts";
 // Swap Configuration
-
-// Initialize Supabase client for realtime and fetching
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-const supabase = createClient(supabaseUrl, supabaseKey);
 
 // Subgraph pool fetcher instance for latest prices
 const subgraphPoolFetcher = createSubgraphPoolFetcher();
@@ -2788,92 +2782,9 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     };
   }, [config?.POOL_CONFIG_YES?.address, config?.POOL_CONFIG_NO?.address, config?.POOL_CONFIG_THIRD?.address, config?.BASE_POOL_CONFIG?.address]); // Only depend on pool addresses
 
-  // Set up realtime WebSocket subscription for instant price updates
-  useEffect(() => {
-    // Don't set up realtime if we don't have pool addresses yet
-    if (!config?.POOL_CONFIG_YES?.address || !config?.POOL_CONFIG_NO?.address) {
-      console.log('[MarketPageShowcase] Waiting for pool addresses before setting up realtime');
-      return;
-    }
-
-    console.log('[MarketPageShowcase] Setting up realtime subscription for pool_candles');
-
-    const poolAddresses = [
-      config.POOL_CONFIG_YES.address.toLowerCase(),
-      config.POOL_CONFIG_NO.address.toLowerCase(),
-      ...(config.POOL_CONFIG_THIRD?.address ? [config.POOL_CONFIG_THIRD.address.toLowerCase()] : []),
-      ...(config.BASE_POOL_CONFIG?.address ? [config.BASE_POOL_CONFIG.address.toLowerCase()] : [])
-    ];
-
-    const channel = supabase
-      .channel('market-showcase-pool-candles')
-      .on('postgres_changes', {
-        event: '*',
-        schema: 'public',
-        table: 'pool_candles',
-        filter: `interval=eq.3600000` // 1 hour interval
-      }, async (payload) => {
-        console.log('[MarketPageShowcase] Realtime pool_candles update:', payload);
-
-        if (!payload.new || !payload.new.address || !payload.new.price) return;
-
-        const poolAddress = payload.new.address.toLowerCase();
-        const newPrice = payload.new.price;
-        const timestamp = payload.new.timestamp;
-
-        // Check if this update is for one of our pools
-        if (!poolAddresses.includes(poolAddress)) {
-          return;
-        }
-
-        console.log(`[MarketPageShowcase] Realtime price update for pool ${poolAddress}: ${newPrice}`);
-
-        // Update the appropriate price based on which pool was updated
-        if (poolAddress === config.POOL_CONFIG_YES.address.toLowerCase()) {
-          // Backend now handles token slot inversion, use raw price directly
-          let adjustedPrice = newPrice;
-
-          setNewYesPrice(adjustedPrice);
-        } else if (poolAddress === config.POOL_CONFIG_NO.address.toLowerCase()) {
-          // Backend now handles token slot inversion, use raw price directly
-          let adjustedPrice = newPrice;
-
-          setNewNoPrice(adjustedPrice);
-          console.log('[MarketPageShowcase] Realtime NO price updated:', adjustedPrice);
-        } else if (config.POOL_CONFIG_THIRD?.address && poolAddress === config.POOL_CONFIG_THIRD.address.toLowerCase()) {
-          // Event probability should use raw price without inversion
-          setNewThirdPrice(newPrice);
-          setThirdCandles((prev) => {
-            const next = prev.filter((candle) => candle.time !== timestamp);
-            next.push({ time: timestamp, value: Number(newPrice) });
-            return next.sort((a, b) => a.time - b.time);
-          });
-          console.log('[MarketPageShowcase] Realtime THIRD price (event probability) updated:', newPrice);
-        } else if (config.BASE_POOL_CONFIG?.address && poolAddress === config.BASE_POOL_CONFIG.address.toLowerCase()) {
-          // Backend now handles currency slot inversion, use raw price directly
-          setNewBasePrice(newPrice);
-          console.log('[MarketPageShowcase] Realtime BASE price updated:', newPrice);
-
-        }
-      })
-      .subscribe((status) => {
-        console.log('[MarketPageShowcase] Realtime subscription status:', status);
-      });
-
-    return () => {
-      console.log('[MarketPageShowcase] Cleaning up realtime subscription');
-      supabase.removeChannel(channel);
-    };
-  }, [
-    config?.POOL_CONFIG_YES?.address,
-    config?.POOL_CONFIG_YES?.tokenCompanySlot,
-    config?.POOL_CONFIG_NO?.address,
-    config?.POOL_CONFIG_NO?.tokenCompanySlot,
-    config?.POOL_CONFIG_THIRD?.address,
-    config?.POOL_CONFIG_THIRD?.tokenCompanySlot,
-    config?.BASE_POOL_CONFIG?.address,
-    config?.BASE_POOL_CONFIG?.currencySlot
-  ]);
+  // NOTE: The Supabase realtime pool_candles subscription that lived here was
+  // removed — the Supabase backend is permanently gone. Prices refresh via the
+  // 30s subgraph polling above.
 
   // Fallback: use subgraph-derived prices when Supabase pool_candles aren't available
   // (e.g., AAVE market has no POOL_CONFIG_YES/NO so Supabase fetch never runs)
@@ -3083,6 +2994,18 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
       fetchMarketData();
     }
   }, [config]);
+
+  // Surface config failures instead of leaving the hero stuck on
+  // "Loading badges…" / "Loading description…" forever
+  useEffect(() => {
+    if (!configLoading && configError) {
+      setMarketData(prev => ({
+        ...prev,
+        isLoading: false,
+        error: configError.message || 'Market data unavailable'
+      }));
+    }
+  }, [configLoading, configError]);
 
   const handleConnectWallet = async () => {
     try {
@@ -4794,11 +4717,6 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     // Optional: Refresh balances after closing the swap modal
     refetchBalances();
   };
-
-  // Initialize Supabase client for fetching market data
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
-  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-  const supabase = createClient(supabaseUrl, supabaseKey);
 
   // Extract hero content for RootLayout
   const marketHero = (

--- a/src/hooks/useContractConfig.js
+++ b/src/hooks/useContractConfig.js
@@ -1,14 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ethers } from 'ethers';
-import { createClient } from '@supabase/supabase-js';
 import { PRECISION_CONFIG } from '../components/futarchyFi/marketPage/constants/contracts';
 import { fetchMarketEventData, parseContractSource } from '../adapters/subgraphConfigAdapter';
 import { fetchProposalMetadataFromRegistry, extractChainFromMetadata, extractSpotPriceFromMetadata, extractStartCandleFromMetadata, extractCloseTimestampFromMetadata, extractTwapFromMetadata, extractResolutionFromMetadata, extractDisplayConfigFromMetadata, extractSnapshotIdFromMetadata } from '../adapters/registryAdapter';
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-const supabase = createClient(supabaseUrl, supabaseKey);
 
 // Public RPCs for the on-chain resolution fallback check
 const RESOLUTION_RPC_BY_CHAIN = {
@@ -59,7 +53,7 @@ async function fetchOnChainResolution(proposalAddress, conditionalTokensAddress,
 }
 
 /**
- * Hook to fetch and manage contract configuration data from Supabase
+ * Hook to fetch and manage contract configuration data from the Registry/subgraph
  * @param {string} proposalId - The proposal ID to fetch configuration for
  * @param {boolean} forceTestPools - Force use of test pool addresses (default: false)
  * @returns {Object} - Contains loading state, error state, contract configuration data, and refetch function
@@ -143,10 +137,15 @@ export const useContractConfig = (proposalId, forceTestPools = false) => {
           if (detectedChain) {
             useContractSource = `subgraph-${detectedChain}`;
             console.log('🔍 Auto-detected chain from Registry:', detectedChain, '→', useContractSource);
-            // Store registry data to enrich subgraph response
-            registryMetadata = registryData;
           } else {
-            console.log('🔍 No chain in Registry metadata, falling back to Supabase');
+            // The legacy Supabase market_event backend is permanently gone; default
+            // to the Gnosis subgraph (with its on-chain fallback) when Registry has no chain.
+            useContractSource = 'subgraph-100';
+            console.log('🔍 No chain in Registry metadata, defaulting to', useContractSource);
+          }
+          // Store registry data (if any) to enrich the subgraph response
+          if (registryData) {
+            registryMetadata = { ...registryData, ...(registryMetadata || {}) };
           }
 
           if (detectedSpotPrice) {
@@ -240,50 +239,7 @@ export const useContractConfig = (proposalId, forceTestPools = false) => {
               };
             }
           } else {
-            console.warn('⚠️ Subgraph fetch failed, falling back to Supabase');
-          }
-        }
-
-        // Fall back to Supabase if no subgraph data or subgraph not specified
-        if (!data) {
-          console.log('📊 Fetching from Supabase...');
-          const { data: supabaseData, error: supabaseError } = await supabase
-            .from('market_event')
-            .select('*')
-            .eq('id', extractedProposalId)
-            .single();
-
-          if (supabaseError) {
-            console.error('Error fetching market event:', supabaseError);
-            throw supabaseError;
-          }
-
-          data = supabaseData;
-
-          // Also enrich Supabase data with Registry metadata if available
-          if (data && (registryMetadata || registrySpotPrice || registryStartCandle || registryCloseTimestamp || registryTwap || registryResolution || registrySnapshotId)) {
-            console.log('📝 Enriching Supabase data with Registry metadata');
-            data._registryMetadata = {
-              displayNameQuestion: registryMetadata?.displayNameQuestion,
-              displayNameEvent: registryMetadata?.displayNameEvent,
-              description: registryMetadata?.description,
-              title: registryMetadata?.title,
-              organization: registryMetadata?.organization,
-              coingecko_ticker: registrySpotPrice,
-              startCandleUnix: registryStartCandle,
-              closeTimestamp: registryCloseTimestamp,
-              owner: registryMetadata?.owner,
-              proposalMetadataAddress: registryMetadata?.id,
-              twapDurationHours: registryTwap?.twapDurationHours || null,
-              twapStartTimestamp: registryTwap?.twapStartTimestamp || null,
-              twapDescription: registryTwap?.twapDescription || null,
-              invertTwapPoolYes: registryTwap?.invertTwapPoolYes || false,
-              invertTwapPoolNo: registryTwap?.invertTwapPoolNo || false,
-              resolution_status: registryResolution?.resolution_status || null,
-              resolution_outcome: registryResolution?.resolution_outcome || null,
-              display: registryMetadata?._displayConfig || null,
-              snapshot_id: registrySnapshotId || null
-            };
+            console.warn('⚠️ Subgraph fetch failed and no fallback backend is available');
           }
         }
 

--- a/src/lib/newDesignMockData.js
+++ b/src/lib/newDesignMockData.js
@@ -136,7 +136,7 @@ export const MOCK_MARKETS = [
             "futarchyAdapter": "0x7495a583ba85875d59407781b4958ED6e0E1228f",
             "proposalAddress": "0xa28614aa999117C555757D56A8178F271C24d7BA",
             "twapDescription": "The Gnosis DAO Futarchy serves to advise delegates and community members on voting decisions, but the results are non-binding.",
-            "background_image": "https://nvhqdqtlsdboctqjcelq.supabase.co/storage/v1/object/public/market-images/market-backgrounds/1759351073623_0epecp.webp",
+            "background_image": null,
             "eventProbability": 0.5,
             "prediction_pools": {
                 "no": {
@@ -287,7 +287,7 @@ export const MOCK_MARKETS = [
             "display_title_1": "if its price is >= 130 sDAI?",
             "futarchyAdapter": "0x7495a583ba85875d59407781b4958ED6e0E1228f",
             "proposalAddress": "0x7e9Fc0C3d6C1619d4914556ad2dEe6051Ce68418",
-            "background_image": "https://nvhqdqtlsdboctqjcelq.supabase.co/storage/v1/object/public/market-images/market-backgrounds/1759351073623_0epecp.webp",
+            "background_image": null,
             "eventProbability": 0.25,
             "prediction_pools": {
                 "no": {

--- a/src/pages/markets/[address].js
+++ b/src/pages/markets/[address].js
@@ -1,8 +1,6 @@
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import { useState, useEffect } from 'react';
-import { createClient } from '@supabase/supabase-js';
-import { 
+import {
   getStaticMarketAddresses, 
   getMarketConfig, 
   generateMarketSEO 
@@ -14,39 +12,7 @@ const MarketPageShowcase = dynamic(
   { ssr: false }
 );
 
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co';
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-const supabase = createClient(supabaseUrl, supabaseKey);
-
 export default function DynamicMarketPage({ address, seoData, marketConfig }) {
-  const [marketData, setMarketData] = useState(null);
-
-  useEffect(() => {
-    const fetchMarketData = async () => {
-      try {
-        const { data, error } = await supabase
-          .from('market_event')
-          .select('*')
-          .eq('id', address)
-          .single();
-        
-        if (error) {
-          console.error('Error fetching market data:', error);
-          return;
-        }
-        
-        setMarketData(data);
-      } catch (err) {
-        console.error('Failed to fetch market data:', err);
-      }
-    };
-
-    if (address) {
-      fetchMarketData();
-    }
-  }, [address]);
-
   // If no config exists, show 404 or redirect
   if (!marketConfig) {
     return (
@@ -141,38 +107,16 @@ export async function getStaticProps({ params }) {
     };
   }
 
-  // Generate SEO data
+  // Generate SEO data from the static market config (the Supabase market_event
+  // backend that used to enrich this at build time is permanently gone)
   const seoData = generateMarketSEO(address);
-  
-  // Optional: Fetch additional market data at build time
-  let marketData = null;
-  try {
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://nvhqdqtlsdboctqjcelq.supabase.co',
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
-    );
-    
-    const { data } = await supabase
-      .from('market_event')
-      .select('*')
-      .eq('id', address)
-      .single();
-    
-    marketData = data;
-  } catch (error) {
-    console.warn(`Failed to fetch market data for ${address} at build time:`, error);
-  }
-
-  // Regenerate SEO data with actual market data if available
-  const finalSeoData = generateMarketSEO(address, marketData);
 
   // Note: revalidate is not supported with output: export
   return {
     props: {
       address,
-      seoData: finalSeoData,
-      marketConfig,
-      marketData
+      seoData,
+      marketConfig
     }
   };
-} 
+}

--- a/src/pages/new-design/[marketId].jsx
+++ b/src/pages/new-design/[marketId].jsx
@@ -1,17 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { createClient } from '@supabase/supabase-js';
 import { MOCK_MARKETS } from '../../lib/newDesignMockData';
 import Link from 'next/link';
 import Head from 'next/head';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { motion } from 'framer-motion';
 import NewSwapInterface from '../../components/new-design/NewSwapInterface';
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function MarketDetailPage() {
   const router = useRouter();
@@ -22,53 +16,17 @@ export default function MarketDetailPage() {
   useEffect(() => {
     if (!marketId) return;
 
-    async function fetchMarket() {
-      setLoading(true);
-      try {
-        console.log("Fetching market from Supabase:", marketId);
-        
-        // Fetch from Supabase first
-        const { data, error } = await supabase
-          .from('market_event')
-          .select('*')
-          .eq('id', marketId)
-          .single();
+    // The Supabase market_event backend is permanently gone; this design
+    // prototype resolves markets from local mock data only.
+    const mockMarket = MOCK_MARKETS.find(m => m.id === marketId || m.proposal_markdown?.includes(marketId));
 
-        if (data) {
-            console.log("Market found in Supabase:", data);
-            setMarket(data);
-            setLoading(false);
-            return;
-        }
-
-        if (error) {
-            console.warn("Supabase fetch error:", error);
-        }
-
-        console.log("Market not found in Supabase, checking mock data...");
-
-        // Fallback to mock data
-        const mockMarket = MOCK_MARKETS.find(m => m.id === marketId || m.proposal_markdown?.includes(marketId));
-        
-        if (mockMarket) {
-            console.log("Market found in mock data:", mockMarket);
-            setMarket(mockMarket);
-        } else {
-            console.warn("Market not found in mock data either.");
-            // Optional: setMarket(MOCK_MARKETS[0]) if you still want a default fallback, 
-            // but user asked to stop mocking, so maybe just leave it null or show error.
-            // For now, keeping the "default to first mock" behavior as a last resort to prevent blank page during dev
-            // setMarket(MOCK_MARKETS[0]); 
-        }
-
-      } catch (err) {
-        console.error("Error fetching market:", err);
-      } finally {
-        setLoading(false);
-      }
+    if (mockMarket) {
+        setMarket(mockMarket);
+    } else {
+        console.warn("Market not found in mock data.");
     }
 
-    fetchMarket();
+    setLoading(false);
   }, [marketId]);
 
   if (loading) {

--- a/src/pages/new-design/index.jsx
+++ b/src/pages/new-design/index.jsx
@@ -1,15 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import { createClient } from '@supabase/supabase-js';
 import { MOCK_MARKETS } from '../../lib/newDesignMockData';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import Head from 'next/head';
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function NewDesignPage() {
   const [markets, setMarkets] = useState([]);
@@ -17,36 +11,10 @@ export default function NewDesignPage() {
   const [filter, setFilter] = useState('all');
 
   useEffect(() => {
-    async function fetchMarkets() {
-      try {
-        setLoading(true);
-        // Attempt to fetch from Supabase
-        const { data, error } = await supabase
-          .from('market_events') // Assuming table name based on context, usually 'markets' or 'proposals'
-          .select('*')
-          .limit(20);
-
-        if (error || !data || data.length === 0) {
-          console.warn("Supabase fetch failed or empty, using mock data:", error);
-          setMarkets(MOCK_MARKETS);
-        } else {
-            // Map supabase data to match structure if needed, or just use it
-            // For now, mixing in mock data if fetch returns very few to ensure UI looks good
-            if (data.length < 5) {
-                 setMarkets([...data, ...MOCK_MARKETS]);
-            } else {
-                 setMarkets(data);
-            }
-        }
-      } catch (err) {
-        console.error("Error fetching markets:", err);
-        setMarkets(MOCK_MARKETS);
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchMarkets();
+    // The Supabase market_events backend is permanently gone; this design
+    // prototype renders from local mock data only.
+    setMarkets(MOCK_MARKETS);
+    setLoading(false);
   }, []);
 
   const filteredMarkets = markets.filter(m => {

--- a/src/utils/getBestRpc.js
+++ b/src/utils/getBestRpc.js
@@ -10,7 +10,6 @@ import { ethers } from 'ethers';
 const RPC_LISTS = {
   1: [ // Ethereum Mainnet
     'https://ethereum-rpc.publicnode.com',
-    'https://eth-mainnet.public.blastapi.io',
     'https://1rpc.io/eth',
     'https://rpc.ankr.com/eth'
   ],


### PR DESCRIPTION
The Supabase project (nvhqdqtlsdboctqjcelq) no longer exists — DNS doesn't resolve — but the frontend still called it, so market pages hung on "Loading badges…/Loading description…" and logged fetch errors for every user.

Removed all live call sites (+64/−420): market_event fetch in useContractConfig (falls back to subgraph-100 → on-chain), both clients + dead realtime subscription in MarketPageShowcase (hero now shows clean unavailable states instead of eternal loading; registry/subgraph markets render unchanged), TripleChart realtime (prop-data only), DynamicShareCard fetches (existing empty state), SEO enrichment in markets/[address] (static config only), new-design pages (local mock data — the de facto behavior already), dead storage image URLs → null, stale UI label. Also removed the shut-down eth blastapi entry from getBestRpc.

Deliberately left: dormant files that import supabase-js but are verified unreachable (MarketHistoryViewModel, RecentTradesDataLayer, MarketPageShowcaseViewModel) — no network calls at module level; removing them is a larger unrelated refactor. Note: mockData.js has a pre-existing syntax error on main (node --check fails identically on origin/main) — untouched here.

npm run build exits 0, all static paths generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)