### PR TITLE
Tier 0 self-serve fixes: market-link 404 fallback + canonical default aggregator

### DIFF
--- a/src/components/debug/CreateOrganizationModal.jsx
+++ b/src/components/debug/CreateOrganizationModal.jsx
@@ -14,11 +14,8 @@ const CONTRACTS = {
     ORGANIZATION_FACTORY: '0x2Fa9318E1e29d7435EE9d23B687b10a9CDDD0d9e',
 };
 
-// Default aggregator (FutarchyFi)
-const DEFAULT_AGGREGATOR = '0x767868874be4b5434bd351410b0b9a6e7f4c3aaf';
-
-// Subgraph endpoint
-import { AGGREGATOR_SUBGRAPH_URL as SUBGRAPH_URL } from '../../config/subgraphEndpoints';
+// Subgraph endpoint + canonical default aggregator (FutarchyFi)
+import { AGGREGATOR_SUBGRAPH_URL as SUBGRAPH_URL, DEFAULT_AGGREGATOR } from '../../config/subgraphEndpoints';
 
 // ABIs (minimal)
 const ORGANIZATION_FACTORY_ABI = [

--- a/src/components/futarchyFi/proposalsList/cards2/ProposalsCard.jsx
+++ b/src/components/futarchyFi/proposalsList/cards2/ProposalsCard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { CheckIcon, CancelIcon, NewspaperIcon, EyeIcon } from "./Resources";
 import Image from 'next/image';
+import { getMarketUrl } from "../../../../utils/urlUtils";
 
 // Move statusColors to the top level, after imports
 const statusColors = {
@@ -150,7 +151,7 @@ const Proposals = ({
         </a>
         <span className={`text-2xl ${statusClasses.separator}`}></span>
         <a
-          href={`/markets/${proposalID}`}
+          href={getMarketUrl(proposalID)}
           className="border-2 border-futarchyGray4 rounded-xl w-1/2 py-3 px-[14px] text-center flex flex-row justify-center gap-[6px]"
           
         >
@@ -372,7 +373,7 @@ export const ProposalsCard = ({
             </div>
           </div>
           <a
-            href={`/markets/${proposalID}`}
+            href={getMarketUrl(proposalID)}
             className="py-2 px-4 bg-black dark:bg-white text-white dark:text-black rounded-lg text-sm font-medium hover:bg-black/90 dark:hover:bg-white/90 transition-colors"
           >
             View Details
@@ -473,7 +474,7 @@ export const MobileProposalsCard = ({
             </div>
           </div>
           <a
-            href={`/markets/${proposalID}`}
+            href={getMarketUrl(proposalID)}
             className="py-2 px-4 bg-black dark:bg-white text-white dark:text-black rounded-lg text-sm font-medium hover:bg-black/90 dark:hover:bg-white/90 transition-colors"
           >
             View Details


### PR DESCRIPTION
Two small self-serve fixes.

## Fix 1 — market links that 404 for new markets

The site is a static export (`output: 'export'`) and `/markets/[address]` pages are generated with `getStaticPaths` (`fallback: false`) over the hardcoded list in `src/config/markets.js`. Any market **not** in that list 404s at `/markets/<address>`, while the query-param form `/market?proposalId=<address>` works for any market (live registry + subgraph fetch).

The live card components (`proposalsList/cards/ProposalsCard.jsx`, `ProposalsCards.jsx`, `EventsCard.jsx`) already route links through `getMarketUrl()` (`src/utils/urlUtils.js`), which emits the query-param form; `src/pages/market.js` then normalizes configured markets back to their pretty static `/markets/<address>` URLs — so the 29 existing markets keep their static URLs.

The one remaining offender was `src/components/futarchyFi/proposalsList/cards2/ProposalsCard.jsx`, which still hardcoded `/markets/${proposalID}` in three places (lines 153/375/476). This PR routes those through `getMarketUrl()` too. Note: `cards2/` currently has no importers (the live proposals list uses `cards/`), so this is a consistency/safety fix — if the variant is ever wired up (or copy-pasted from) it will no longer generate 404 links for unlisted markets.

## Fix 2 — wrong default aggregator in debug modal

`src/components/debug/CreateOrganizationModal.jsx` defaulted the aggregator field to `0x767868874be4b5434bd351410b0b9a6e7f4c3aaf`, which is not the canonical aggregator. The canonical address `0xC5eB43D53e2FE5FddE5faf400CC4167e5b5d4Fc1` is already the shared `DEFAULT_AGGREGATOR` export in `src/config/subgraphEndpoints.js` (and matches `registryAdapter.js` and `marketPage/constants/contracts.js`). The modal now imports that shared constant instead of carrying its own stale literal. No other call sites touched.

## Verification

- `npm run build` (static export) passes; all 29 static market paths still generated.
- `npm run auto-qa:test:unit`: 691 pass / 0 fail — no test baselines needed updating (no test pinned the old aggregator literal or the cards2 link format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)