### PR TITLE
SEO: absolute og:image + futarchy.fi origin — fixes Telegram link previews

### DIFF
--- a/scripts/generate-seo.mjs
+++ b/scripts/generate-seo.mjs
@@ -43,7 +43,7 @@ import path from 'path';
 const REGISTRY_GRAPHQL_URL =
   process.env.REGISTRY_GRAPHQL_URL || 'https://api.futarchy.fi/registry/graphql';
 const DEFAULT_AGGREGATOR = '0xc5eb43d53e2fe5fdde5faf400cc4167e5b5d4fc1';
-const SITE_ORIGIN = 'https://app.futarchy.fi';
+const SITE_ORIGIN = 'https://futarchy.fi';
 const DEFAULT_IMAGE = '/assets/futarchy-logo-gray.png';
 
 const LEGACY_SEO_PATH = path.join(process.cwd(), 'src', 'config', 'legacy-seo.json');
@@ -269,7 +269,7 @@ function buildRegistryEntry({ addressKey, entity, org, mappedSeoByAddress, nowSe
     openGraph: {
       title: `${title} | Futarchy.fi`,
       description,
-      image,
+      image: image.startsWith('http') ? image : `${SITE_ORIGIN}${image}`,
       type: 'website',
       siteName: 'Futarchy.fi',
     },

--- a/src/config/markets.js
+++ b/src/config/markets.js
@@ -1303,7 +1303,7 @@ export const MARKETS_CONFIG = {
     "openGraph": {
       "title": "TEST4-Will 'GIP-133: Should Gnosis DAO extend the Gnosis Pay Cashback budget (GIP-110) by 2,000 GNO?' be approved ('Yes') or rejected ('No') by GnosisDAO? If unresolved by 2025-09-30 23:59 UTC, it resolves to 'No'. | Futarchy.fi",
       "description": "Live futarchy prediction market by Gnosis: TEST4-Will 'GIP-133: Should Gnosis DAO extend the Gnosis Pay Cashback budget (GIP-110) by 2,000 GNO?' be approved ...",
-      "image": "/assets/futarchy-logo-gray.png",
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png",
       "type": "website",
       "siteName": "Futarchy.fi"
     },
@@ -1311,7 +1311,7 @@ export const MARKETS_CONFIG = {
       "card": "summary_large_image",
       "title": "TEST4-Will 'GIP-133: Should Gnosis DAO extend the Gnosis Pay Cashback budget (GIP-110) by 2,000 GNO?' be approved ('Yes') or rejected ('No') by GnosisDAO? If unresolved by 2025-09-30 23:59 UTC, it resolves to 'No'. | Futarchy.fi",
       "description": "Live futarchy prediction market by Gnosis: TEST4-Will 'GIP-133: Should Gnosis DAO extend the Gnosis Pay Cashback budget (GIP-110) by 2,000 GNO?' be approved ...",
-      "image": "https://app.futarchy.fi/assets/futarchy-logo-gray.png"
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png"
     },
     "keywords": [
       "futarchy",
@@ -1384,7 +1384,7 @@ export const MARKETS_CONFIG = {
     "openGraph": {
       "title": "What will the impact on ETH price be if EIP-8363 is Scheduled for Inclusion in Hegotá? | Futarchy.fi",
       "description": "Resolves YES if, at any time before 2026-10-24 00:00 UTC, EIP-8363 is listed under the 'Scheduled for Inclusion' section of EIP-8081 (Hardfork Meta - Hegotá) as merged in the master branch of the ethereum/EIPs GitHub repository. If EIP-8081 is renumbered or replaced, the successor Hardfork Meta EIP for the same network upgrade counts. Listing under any other section does not count. Later removal after listing does not change a YES. Only EIP number 8363 counts. Otherwise resolves NO.",
-      "image": "/assets/eth-eip8363-market-card.png",
+      "image": "https://futarchy.fi/assets/eth-eip8363-market-card.png",
       "type": "website",
       "siteName": "Futarchy.fi"
     },
@@ -1392,7 +1392,7 @@ export const MARKETS_CONFIG = {
       "card": "summary_large_image",
       "title": "What will the impact on ETH price be if EIP-8363 is Scheduled for Inclusion in Hegotá? | Futarchy.fi",
       "description": "Resolves YES if, at any time before 2026-10-24 00:00 UTC, EIP-8363 is listed under the 'Scheduled for Inclusion' section of EIP-8081 (Hardfork Meta - Hegotá) as merged in the master branch of the ethereum/EIPs GitHub repository. If EIP-8081 is renumbered or replaced, the successor Hardfork Meta EIP for the same network upgrade counts. Listing under any other section does not count. Later removal after listing does not change a YES. Only EIP number 8363 counts. Otherwise resolves NO.",
-      "image": "https://app.futarchy.fi/assets/eth-eip8363-market-card.png"
+      "image": "https://futarchy.fi/assets/eth-eip8363-market-card.png"
     },
     "keywords": [
       "futarchy",
@@ -1545,7 +1545,7 @@ export const MARKETS_CONFIG = {
     "openGraph": {
       "title": "What impact will be on GNO if GIP-XX pass? | Futarchy.fi",
       "description": "GIP-XX is lorem ipsum",
-      "image": "/assets/futarchy-logo-gray.png",
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png",
       "type": "website",
       "siteName": "Futarchy.fi"
     },
@@ -1553,7 +1553,7 @@ export const MARKETS_CONFIG = {
       "card": "summary_large_image",
       "title": "What impact will be on GNO if GIP-XX pass? | Futarchy.fi",
       "description": "GIP-XX is lorem ipsum",
-      "image": "https://app.futarchy.fi/assets/futarchy-logo-gray.png"
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png"
     },
     "keywords": [
       "futarchy",
@@ -1665,7 +1665,7 @@ export const MARKETS_CONFIG = {
     "openGraph": {
       "title": "What will the impact on PNK price be if KIP-86 is approved? | Futarchy.fi",
       "description": "Will KIP-86 (Exclude PNK held by the Kleros Cooperative from KIP-66) be approved ('Yes') or rejected ('No') by Kleros Governance? If proposal is not approved by the end of March 2026, results as ('No').",
-      "image": "/assets/futarchy-logo-gray.png",
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png",
       "type": "website",
       "siteName": "Futarchy.fi"
     },
@@ -1673,7 +1673,7 @@ export const MARKETS_CONFIG = {
       "card": "summary_large_image",
       "title": "What will the impact on PNK price be if KIP-86 is approved? | Futarchy.fi",
       "description": "Will KIP-86 (Exclude PNK held by the Kleros Cooperative from KIP-66) be approved ('Yes') or rejected ('No') by Kleros Governance? If proposal is not approved by the end of March 2026, results as ('No').",
-      "image": "https://app.futarchy.fi/assets/futarchy-logo-gray.png"
+      "image": "https://futarchy.fi/assets/futarchy-logo-gray.png"
     },
     "keywords": [
       "futarchy",
@@ -1780,13 +1780,13 @@ export function generateMarketSEO(address, marketData = null) {
     title: `${title} | Futarchy.fi`,
     description,
     image,
-    url: `https://app.futarchy.fi${config.path}`,
+    url: `https://futarchy.fi${config.path}`,
     openGraph: {
       ...config.openGraph,
       title: marketData?.seoTitle ? `${marketData.seoTitle} | Futarchy.fi` : config.openGraph.title,
       description: marketData?.seoDescription || config.openGraph.description,
       image: marketData?.seoImage || config.openGraph.image,
-      url: `https://app.futarchy.fi${config.path}`
+      url: `https://futarchy.fi${config.path}`
     },
     twitter: {
       ...config.twitter,

--- a/src/pages/markets/[address].js
+++ b/src/pages/markets/[address].js
@@ -63,7 +63,7 @@ export default function DynamicMarketPage({ address, seoData, marketConfig }) {
             "publisher": {
               "@type": "Organization",
               "name": "Futarchy.fi",
-              "url": "https://app.futarchy.fi"
+              "url": "https://futarchy.fi"
             },
             "category": marketConfig.category,
             "keywords": marketConfig.keywords?.join(', ')


### PR DESCRIPTION
og:image was a relative path (preview fetchers require absolute) and og:url/twitter:image used the dead app.futarchy.fi domain. SITE_ORIGIN → https://futarchy.fi and openGraph.image is now absolutized in the generator; regenerated markets.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)