### PR TITLE
Display sweep: debug chrome, precision, wei amounts, real liquidity, currency labels, view card

### DIFF
--- a/auto-qa/tests/liquidity-math.test.mjs
+++ b/auto-qa/tests/liquidity-math.test.mjs
@@ -1,106 +1,63 @@
 /**
- * Liquidity math unit-bound test (auto-qa).
+ * Real-reserve liquidity display tests (auto-qa).
  *
- * Pins the math fix from PR #51 — converting Algebra V3's raw `liquidity`
- * field (1e18-scaled) to a currency-denominated TVL via:
- *   TVL_currency = (2 × L × sqrtPrice) / 1e18      (when currency is token1)
- *   TVL_currency = (2 × L / sqrtPrice) / 1e18      (when currency is token0)
- * where sqrtPrice = 1.0001^(tick/2).
- *
- * Pre-PR-#51, the widget displayed the raw L value as "sDAI" — values
- * like "4.9e21 sDAI" — nonsense.
- *
- * This is a SPEC test: the math here mirrors the production code at
- * `src/hooks/usePoolData.js:141-153`. If those lines change, this test
- * may need a synchronized update — that's the contract.
+ * Concentrated-liquidity L is virtual and must not be presented as deposited
+ * reserves. Production reads both ERC20 balances held by each pool and values
+ * the company-token side at the pool's current currency price.
  */
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
-/**
- * Mirrors the production calculation at src/hooks/usePoolData.js:141-153.
- * @param {string|number} rawL  Algebra V3 `liquidity` field (1e18-scaled BigInt).
- * @param {number}        tick  Current pool tick.
- * @param {boolean}       currencyIsToken0
- * @returns {number} TVL in currency token units (NOT wei), or 0 if tick missing.
- */
-function tvlFromTick(rawL, tick, currencyIsToken0) {
-    let adjustedLiquidity = parseFloat(rawL || 0);
-    if (tick === undefined || tick === null) return adjustedLiquidity / 1e18;
-    const sqrtPrice = Math.pow(1.0001, tick / 2);
-    if (!(sqrtPrice > 0)) return 0;
-    const liquidityScaled = currencyIsToken0
-        ? adjustedLiquidity / sqrtPrice
-        : adjustedLiquidity * sqrtPrice;
-    return (liquidityScaled * 2) / 1e18;
-}
+const POOL_DATA_SRC = readFileSync(
+    new URL('../../src/hooks/usePoolData.js', import.meta.url),
+    'utf8',
+);
+const MARKET_PAGE_SRC = readFileSync(
+    new URL('../../src/components/futarchyFi/marketPage/MarketPageShowcase.jsx', import.meta.url),
+    'utf8',
+);
 
-// ────────────────────────────────────────────────────────────────────────
-// Fixture: GIP-150 v2 CONDITIONAL pool data captured from live API.
-// ────────────────────────────────────────────────────────────────────────
-const YES_POOL = {
-    L: '4900580174367112592095',
-    tick: 47116,
-    currencyIsToken0: false, // token0=YES_GNO, token1=YES_sDAI
-};
-const NO_POOL = {
-    L: '4900580174367112321476',
-    tick: -46766,
-    currencyIsToken0: true,  // token0=NO_sDAI, token1=NO_GNO
-};
+const valueRealReserves = ({ currencyAmount, companyAmount, companyPrice }) =>
+    currencyAmount + (companyAmount * companyPrice);
 
-test('PR #51 — YES pool TVL is in plausible currency-units range', () => {
-    const tvl = tvlFromTick(YES_POOL.L, YES_POOL.tick, YES_POOL.currencyIsToken0);
-    assert.ok(tvl > 1,
-        `YES pool TVL must be > 1 sDAI; got ${tvl}`);
-    assert.ok(tvl < 1e9,
-        `YES pool TVL must be < 1e9 sDAI (raw 1e18 leak guard); got ${tvl}`);
-    // Sanity: GIP-150's CONDITIONAL pools sit around 100K sDAI TVL.
-    assert.ok(tvl > 1e4 && tvl < 1e7,
-        `YES pool TVL should be in 10K..10M range for GIP-150; got ${tvl}`);
+test('real reserves are valued as currency + company × current pool price', () => {
+    assert.equal(valueRealReserves({
+        currencyAmount: 100_000,
+        companyAmount: 100_000,
+        companyPrice: 0.5205,
+    }), 152_050);
 });
 
-test('PR #51 — NO pool TVL is in plausible currency-units range', () => {
-    const tvl = tvlFromTick(NO_POOL.L, NO_POOL.tick, NO_POOL.currencyIsToken0);
-    assert.ok(tvl > 1, `NO pool TVL must be > 1 sDAI; got ${tvl}`);
-    assert.ok(tvl < 1e9, `NO pool TVL must be < 1e9 sDAI; got ${tvl}`);
-    assert.ok(tvl > 1e4 && tvl < 1e7,
-        `NO pool TVL should be in 10K..10M range for GIP-150; got ${tvl}`);
+test('valuation is independent of pool token ordering', () => {
+    const token0Currency = valueRealReserves({
+        currencyAmount: 85_000,
+        companyAmount: 42_000,
+        companyPrice: 1.25,
+    });
+    const token1Currency = valueRealReserves({
+        companyAmount: 42_000,
+        currencyAmount: 85_000,
+        companyPrice: 1.25,
+    });
+    assert.equal(token0Currency, token1Currency);
 });
 
-test('PR #51 — YES and NO TVL are within 50% of each other (futarchy invariant)', () => {
-    // For a healthy futarchy market the YES and NO conditional pools
-    // start with the same liquidity. They drift but should stay
-    // within an order of magnitude. If one is 100× the other, the
-    // tick-based formula is broken on one side.
-    const yesTvl = tvlFromTick(YES_POOL.L, YES_POOL.tick, YES_POOL.currencyIsToken0);
-    const noTvl  = tvlFromTick(NO_POOL.L,  NO_POOL.tick,  NO_POOL.currencyIsToken0);
-    const ratio = Math.max(yesTvl, noTvl) / Math.min(yesTvl, noTvl);
-    assert.ok(ratio < 2,
-        `YES and NO TVL should be within 2x of each other; got ratio ${ratio.toFixed(2)} (YES=${yesTvl.toFixed(0)} NO=${noTvl.toFixed(0)})`);
+test('pool data reads both real ERC20 balances and formats token decimals', () => {
+    const balanceReads = POOL_DATA_SRC.match(/\.balanceOf\(poolAddress\)/g) || [];
+    assert.equal(balanceReads.length, 2);
+    assert.match(POOL_DATA_SRC, /formatUnits\(balance0, Number\(t0\.decimals \?\? 18\)\)/);
+    assert.match(POOL_DATA_SRC, /formatUnits\(balance1, Number\(t1\.decimals \?\? 18\)\)/);
 });
 
-test('PR #51 — fallback /1e18 when tick missing yields plausible value', () => {
-    const tvl = tvlFromTick(YES_POOL.L, null, false);
-    // Without tick, formula falls back to L / 1e18 ≈ 4900 (raw L is
-    // a 1e18-scaled BigInt). This is a degraded fallback but still
-    // bounded — must not leak the raw 1e21 value.
-    assert.ok(tvl > 1 && tvl < 1e9,
-        `fallback TVL out of bounds: ${tvl}`);
+test('virtual-liquidity reserve approximation is absent', () => {
+    assert.doesNotMatch(POOL_DATA_SRC, /liquidityScaled|adjustedLiquidity|sqrtPrice/);
 });
 
-test('PR #51 — degenerate tick (sqrtPrice=0) returns 0, not Infinity/NaN', () => {
-    // Algebra V3 ticks are bounded in [-887272, 887272]. At extreme
-    // negative ticks Math.pow(1.0001, tick/2) underflows to 0 — the
-    // production guard returns 0 rather than dividing by zero.
-    const tvl = tvlFromTick('1000000000000000000', -1_000_000, true);
-    assert.ok(tvl === 0 || (Number.isFinite(tvl) && tvl >= 0),
-        `extreme negative tick should not yield Infinity/NaN; got ${tvl}`);
-});
-
-test('PR #51 — null/zero L returns 0, not NaN', () => {
-    assert.equal(tvlFromTick(null, 0, false), 0);
-    assert.equal(tvlFromTick(undefined, 0, false), 0);
-    assert.equal(tvlFromTick('0', 0, false), 0);
+test('market stat classifies reserve sides and applies the pool price', () => {
+    assert.match(MARKET_PAGE_SRC, /entry\.kind === 'currency'/);
+    assert.match(MARKET_PAGE_SRC, /entry\.kind === 'company'/);
+    assert.match(MARKET_PAGE_SRC, /companyTokenAmount \* price/);
+    assert.match(MARKET_PAGE_SRC, /label="Liquidity"/);
 });

--- a/auto-qa/tests/precision-formatter.test.mjs
+++ b/auto-qa/tests/precision-formatter.test.mjs
@@ -84,6 +84,23 @@ function getPrecision(type = 'default', config = null) {
     return precisionConfig?.display?.[type] ?? precisionConfig?.display?.default ?? 2;
 }
 
+function formatTokenAmount(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num === 0) return '0.00';
+
+    const absolute = Math.abs(num);
+    let fractionDigits = 2;
+    if (absolute < 1) {
+        fractionDigits = Math.min(8, Math.max(4, 3 - Math.floor(Math.log10(absolute))));
+    }
+
+    return num.toLocaleString('en-US', {
+        useGrouping: false,
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
+    });
+}
+
 // ---------------------------------------------------------------------------
 // formatWith — invalid input handling
 // ---------------------------------------------------------------------------
@@ -176,6 +193,28 @@ test('formatWith — smart-precision strips trailing zeros after bump', () => {
 test('formatWith — accepts string and number forms equivalently', () => {
     assert.equal(formatWith(1.5, 'price'), formatWith('1.5', 'price'));
     assert.equal(formatWith(0.001, 'amount'), formatWith('0.001', 'amount'));
+});
+
+// ---------------------------------------------------------------------------
+// formatTokenAmount — adaptive receive/outcome precision
+// ---------------------------------------------------------------------------
+
+test('formatTokenAmount — always shows at least two decimals', () => {
+    assert.equal(formatTokenAmount(0), '0.00');
+    assert.equal(formatTokenAmount(1), '1.00');
+    assert.equal(formatTokenAmount(12.345), '12.35');
+});
+
+test('formatTokenAmount — values below one retain four significant digits', () => {
+    assert.equal(formatTokenAmount(0.5205), '0.5205');
+    assert.equal(formatTokenAmount(0.5), '0.5000');
+    assert.equal(formatTokenAmount(0.05205), '0.05205');
+});
+
+test('formatTokenAmount — tiny values use at most eight decimals and never exponent notation', () => {
+    const formatted = formatTokenAmount(0.000000261);
+    assert.equal(formatted, '0.00000026');
+    assert.doesNotMatch(formatted, /e/i);
 });
 
 // ---------------------------------------------------------------------------

--- a/auto-qa/tests/subgraph-trades-client.test.mjs
+++ b/auto-qa/tests/subgraph-trades-client.test.mjs
@@ -43,8 +43,8 @@
  *   8. Event side detection — outcomeSide first (lowercased), then
  *      symbol startsWith YES/NO fallback. Default 'neutral'.
  *
- *   9. Format tiers — formatAmount has 6 tiers; formatPrice branches
- *      on poolType === 'PREDICTION' for percentage display.
+ *   9. Amount units — raw 18-decimal values are converted from wei and
+ *      rendered with adaptive precision, never scientific notation.
  *
  *  10. Sort order — fetchFormattedTrades sorts trades DESCENDING by
  *      date (b.date - a.date). Comment notes pool_in queries don't
@@ -66,18 +66,35 @@ const SRC = readFileSync(
 
 // ───── spec mirrors (private functions in source) ─────
 
+function formatTokenAmount(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num === 0) return '0.00';
+    const absolute = Math.abs(num);
+    const fractionDigits = absolute < 1
+        ? Math.min(8, Math.max(4, 3 - Math.floor(Math.log10(absolute))))
+        : 2;
+    return num.toLocaleString('en-US', {
+        useGrouping: false,
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits,
+    });
+}
+
+function formatUnits18(value) {
+    const raw = BigInt(value);
+    const negative = raw < 0n;
+    const digits = (negative ? -raw : raw).toString().padStart(19, '0');
+    const whole = digits.slice(0, -18);
+    const fraction = digits.slice(-18).replace(/0+$/, '') || '0';
+    return `${negative ? '-' : ''}${whole}.${fraction}`;
+}
+
 function formatAmount(value) {
-    const num = parseFloat(value);
-    if (isNaN(num) || num === 0) return '0';
-
-    const absNum = Math.abs(num);
-
-    if (absNum < 0.000001) return num.toExponential(2);
-    if (absNum < 0.001) return num.toPrecision(3);
-    if (absNum < 1) return num.toFixed(6);
-    if (absNum < 1000) return num.toFixed(4);
-    if (absNum < 1000000) return num.toFixed(2);
-    return num.toExponential(2);
+    try {
+        return formatTokenAmount(formatUnits18(value || '0'));
+    } catch {
+        return formatTokenAmount(value);
+    }
 }
 
 function formatPrice(price, poolType) {
@@ -218,12 +235,12 @@ test('stitched swap fallback preserves {id,name:null,type:null,outcomeSide:null}
 
 test('UI tokenIN comes FROM swap.tokenOut (user receives) — inversion preserved', () => {
     assert.match(SRC, /tokenIN:\s*\{[^}]*symbol:\s*swap\.tokenOut\?\.symbol/);
-    assert.match(SRC, /tokenIN:\s*\{[^}]*value:\s*formatAmount\(swap\.amountOut\)/);
+    assert.match(SRC, /tokenIN:\s*\{[^}]*value:\s*formatAmount\(swap\.amountOut,[^)]+\)/);
 });
 
 test('UI tokenOUT comes FROM swap.tokenIn (user gives) — inversion preserved', () => {
     assert.match(SRC, /tokenOUT:\s*\{[^}]*symbol:\s*swap\.tokenIn\?\.symbol/);
-    assert.match(SRC, /tokenOUT:\s*\{[^}]*value:\s*formatAmount\(swap\.amountIn\)/);
+    assert.match(SRC, /tokenOUT:\s*\{[^}]*value:\s*formatAmount\(swap\.amountIn,[^)]+\)/);
 });
 
 test('inversion explainer comment is present (load-bearing for new contributors)', () => {
@@ -343,43 +360,23 @@ test('classifyEventSide: default neutral when nothing matches', () => {
     );
 });
 
-// ───── 9. Format tiers ─────
+// ───── 9. Raw amount units + adaptive display ─────
 
-test('formatAmount: 0/NaN/empty → "0"', () => {
-    assert.equal(formatAmount(0), '0');
-    assert.equal(formatAmount('0'), '0');
-    assert.equal(formatAmount('not-a-number'), '0');
-    assert.equal(formatAmount(NaN), '0');
+test('formatAmount: converts raw 18-decimal values before display', () => {
+    assert.equal(formatAmount('520500000000000000'), '0.5205');
+    assert.equal(formatAmount('1000000000000000000'), '1.00');
+    assert.equal(formatAmount('123456789000000000000'), '123.46');
 });
 
-test('formatAmount: <0.000001 → exponential(2)', () => {
-    assert.equal(formatAmount('0.0000005'), '5.00e-7');
+test('formatAmount: tiny raw wei never renders in exponent notation', () => {
+    const formatted = formatAmount('261000000000');
+    assert.equal(formatted, '0.00000026');
+    assert.doesNotMatch(formatted, /e/i);
 });
 
-test('formatAmount: <0.001 → toPrecision(3)', () => {
-    assert.equal(formatAmount('0.000234'), '0.000234');
-    assert.equal(formatAmount('0.0001234'), '0.000123');
-});
-
-test('formatAmount: <1 → toFixed(6)', () => {
-    assert.equal(formatAmount('0.123456789'), '0.123457');
-});
-
-test('formatAmount: <1000 → toFixed(4)', () => {
-    assert.equal(formatAmount('123.4567890'), '123.4568');
-});
-
-test('formatAmount: <1000000 → toFixed(2)', () => {
-    assert.equal(formatAmount('12345.6789'), '12345.68');
-});
-
-test('formatAmount: ≥1000000 → exponential(2)', () => {
-    assert.equal(formatAmount('1234567.89'), '1.23e+6');
-});
-
-test('formatAmount: handles negatives via Math.abs in tier check', () => {
-    // Negative within <1 tier → toFixed(6) preserves sign
-    assert.equal(formatAmount('-0.5'), '-0.500000');
+test('formatAmount: production source uses decimals-aware ethers formatUnits and shared formatter', () => {
+    assert.match(SRC, /ethers\.utils\.formatUnits\(value \|\| '0', Number\(decimals\) \|\| 18\)/);
+    assert.match(SRC, /return formatTokenAmount\(/);
 });
 
 test('formatPrice: PREDICTION pool → percentage with 2-decimal precision', () => {

--- a/src/components/chart/SubgraphChart.jsx
+++ b/src/components/chart/SubgraphChart.jsx
@@ -5,6 +5,7 @@ import { createChart, LineSeries } from 'lightweight-charts';
 import { useSubgraphData } from '../../hooks/useSubgraphData';
 import { formatWith } from '../../utils/precisionFormatter';
 import { useSubgraphRefresh } from '../../contexts/SubgraphRefreshContext';
+import { SHOW_DATA_DEBUG } from '../../config/featureFlags';
 
 /**
  * SubgraphChart - A chart component that fetches data from The Graph subgraphs
@@ -527,7 +528,9 @@ const SubgraphChart = ({
     const impactColorClass = impact >= 0 ? '!text-futarchyTeal7' : '!text-futarchyCrimson7';
 
     // Get currency from config
-    const currency = config?.BASE_TOKENS_CONFIG?.currency?.symbol || 'sDAI';
+    const currency = config?.BASE_TOKENS_CONFIG?.currency?.symbol ||
+        config?.metadata?.currencyTokens?.base?.tokenSymbol ||
+        (Number(chainId) === 1 ? 'USDS' : 'sDAI');
     const companySymbol = config?.BASE_TOKENS_CONFIG?.company?.symbol || 'TOKEN';
     const tradingPair = `${companySymbol}/${currency}`;
 
@@ -542,7 +545,7 @@ const SubgraphChart = ({
                     <div className="flex-1 flex flex-col items-center justify-center text-center border-r-2 border-futarchyGray62 dark:border-futarchyGray112/40 first:rounded-tl-3xl px-1">
                         <span className="text-[9px] md:text-xs text-futarchyGray11 dark:text-white/70 font-medium flex items-center gap-1">
                             Trading Pair
-                            <span className="text-[8px] bg-futarchyViolet9/20 dark:bg-futarchyViolet7/20 text-futarchyViolet9 dark:text-futarchyViolet7 px-1 rounded">SUBGRAPH</span>
+                            {SHOW_DATA_DEBUG && <span className="text-[8px] bg-futarchyViolet9/20 dark:bg-futarchyViolet7/20 text-futarchyViolet9 dark:text-futarchyViolet7 px-1 rounded">SUBGRAPH</span>}
                         </span>
                         <span className="text-[9px] md:text-sm font-bold text-futarchyGray12 dark:text-white">{tradingPair}</span>
                     </div>
@@ -599,7 +602,7 @@ const SubgraphChart = ({
                     </div>
 
                     {/* Resync Button with Countdown */}
-                    <div className="flex-1 flex flex-col items-center justify-center text-center px-2 last:rounded-tr-3xl">
+                    {SHOW_DATA_DEBUG && <div className="flex-1 flex flex-col items-center justify-center text-center px-2 last:rounded-tr-3xl">
                         <button
                             onClick={() => {
                                 refetch(false); // Manual click shows loading
@@ -623,7 +626,7 @@ const SubgraphChart = ({
                             </svg>
                             {loading ? 'Syncing...' : `Resync (${countdown}s)`}
                         </button>
-                    </div>
+                    </div>}
                 </div>
             </div>
 
@@ -635,7 +638,7 @@ const SubgraphChart = ({
                         <div className="absolute inset-0 flex items-center justify-center bg-white/50 dark:bg-black/50 z-10">
                             <div className="flex items-center gap-2">
                                 <div className="w-5 h-5 border-2 border-futarchyViolet9 dark:border-futarchyViolet7 border-t-transparent rounded-full animate-spin" />
-                                <span className="text-sm text-gray-600 dark:text-gray-400 font-oxanium">Loading from subgraph...</span>
+                                <span className="text-sm text-gray-600 dark:text-gray-400 font-oxanium">{SHOW_DATA_DEBUG ? 'Loading from subgraph...' : 'Loading chart...'}</span>
                             </div>
                         </div>
                     )}
@@ -678,7 +681,7 @@ const SubgraphChart = ({
             </div>
 
             {/* Footer with pool info and data stats */}
-            <div className="px-4 py-2 border-t border-futarchyGray62 dark:border-futarchyGray11/70 bg-futarchyGray2/50 dark:bg-futarchyDarkGray2/50">
+            {SHOW_DATA_DEBUG && <div className="px-4 py-2 border-t border-futarchyGray62 dark:border-futarchyGray11/70 bg-futarchyGray2/50 dark:bg-futarchyDarkGray2/50">
                 <div className="flex items-center justify-between text-[10px] text-gray-500 dark:text-gray-400 font-oxanium">
                     <span className="flex items-center gap-4">
                         {yesPool && <span>YES: {yesPool.name}</span>}
@@ -689,7 +692,7 @@ const SubgraphChart = ({
                         {lastUpdated && <span>Updated: {lastUpdated.toLocaleDateString([], { month: 'short', day: 'numeric' })} {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}</span>}
                     </span>
                 </div>
-            </div>
+            </div>}
         </div>
     );
 };

--- a/src/components/futarchyFi/companyList/cards/deafultCards/CompaniesCard.jsx
+++ b/src/components/futarchyFi/companyList/cards/deafultCards/CompaniesCard.jsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import FutarchyTileAnimation from "../../components/FutarchyTileAnimation";
 import { generateFallbackImage } from "../../../../../utils/imageUtils";
 import EditCompanyModal from "../../../../debug/EditCompanyModal";
+import { SHOW_DATA_DEBUG } from "../../../../../config/featureFlags";
 
 const getStorybookUrl = (companyId) => {
   // Map company IDs to their proper Storybook story names
@@ -80,9 +81,9 @@ export const CompaniesCard = ({
     <>
       <a href={href} className="group relative block border-2 border-futarchyGray62 dark:border-futarchyGray11/70 rounded-3xl w-full md:w-[340px] shadow-sm hover:shadow-lg transition-colors duration-300 overflow-hidden bg-futarchyGray3 dark:bg-futarchyDarkGray2">
         {/* Badges Container */}
-        {(fromSubgraph || isOwner) && (
+        {((SHOW_DATA_DEBUG && fromSubgraph) || isOwner) && (
           <div className="absolute top-2 right-2 z-30 flex flex-col gap-1">
-            {fromSubgraph && (
+            {SHOW_DATA_DEBUG && fromSubgraph && (
               <div className="bg-purple-600 text-white text-xs font-bold px-2 py-1 rounded-full shadow-lg">
                 📊 Subgraph
               </div>
@@ -187,4 +188,3 @@ export const CompaniesCard = ({
     </>
   );
 };
-

--- a/src/components/futarchyFi/companyList/cards/highlightCards/EventHighlightCard.jsx
+++ b/src/components/futarchyFi/companyList/cards/highlightCards/EventHighlightCard.jsx
@@ -293,7 +293,7 @@ const EventHighlightCard = ({
   // Extract base token symbol from metadata
   const baseTokenSymbol = metadata?.currencyTokens?.base?.tokenSymbol ||
     metadata?.BASE_TOKENS_CONFIG?.currency?.symbol ||
-    'SDAI';
+    (Number(metadata?.chain || chainId) === 1 ? 'USDS' : 'sDAI');
 
   // Use high precision for small prices
   const shouldUseHighPrecision = (prices.no !== null && prices.no < 1) ||

--- a/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
+++ b/src/components/futarchyFi/companyList/cards/highlightCards/HighlightCards.jsx
@@ -3,6 +3,7 @@ import CircularProgressBar from "../../components/CircularProgressBar";
 import { createSubgraphPoolFetcher } from "../../../../../utils/SubgraphPoolFetcher";
 import { generateMarketUrl } from "../../constants/staticPaths";
 import ChainBadge from "../../components/ChainBadge";
+import { SHOW_DATA_DEBUG } from "../../../../../config/featureFlags";
 
 // Subgraph-backed pool fetcher (replaces SupabasePoolFetcher)
 const poolFetcher = createSubgraphPoolFetcher();
@@ -190,6 +191,7 @@ const HighlightCard = ({
   finalOutcome,
   impact: impactProp,
   companySymbol = 'GNO',
+  currencySymbol,
   // Pool addresses for price fetching
   poolAddresses,
   metadata,
@@ -320,8 +322,8 @@ const HighlightCard = ({
   // Extract base token symbol from metadata
   const baseTokenSymbol = metadata?.currencyTokens?.base?.tokenSymbol ||
     metadata?.BASE_TOKENS_CONFIG?.currency?.symbol ||
-    companySymbol ||
-    'SDAI';
+    currencySymbol ||
+    (Number(metadata?.chain || chainId) === 1 ? 'USDS' : 'sDAI');
 
   const renderValue = (value, format) => {
     if (isLoading) return <LoadingSpinner />;
@@ -446,12 +448,12 @@ const HighlightCard = ({
                 </button>
               )}
               {/* Data Source Badge */}
-              <span className={`px-2 py-1 rounded-lg text-xs font-medium ${priceSource === 'subgraph'
+              {SHOW_DATA_DEBUG && <span className={`px-2 py-1 rounded-lg text-xs font-medium ${priceSource === 'subgraph'
                 ? 'bg-green-500/20 text-green-400 border border-green-500/30'
                 : 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
                 }`}>
                 {priceSource === 'subgraph' ? '📊 Subgraph' : '📊 Subgraph (per-pool)'}
-              </span>
+              </span>}
               {chainId && <ChainBadge chainId={chainId} size="sm" />}
             </div>
           </div>

--- a/src/components/futarchyFi/companyList/page/ResolvedEventsDataTransformer.jsx
+++ b/src/components/futarchyFi/companyList/page/ResolvedEventsDataTransformer.jsx
@@ -63,7 +63,8 @@ export const fetchResolvedEventHighlightData = async (_companyId = "all", limit 
         metadata: proposal.metadata,
         companyId: proposal.companyId,
         companySymbol: proposal.metadata?.companyTokens?.base?.tokenSymbol || 'GNO',
-        currencySymbol: proposal.metadata?.currencyTokens?.base?.tokenSymbol || 'sDAI',
+        currencySymbol: proposal.metadata?.currencyTokens?.base?.tokenSymbol ||
+          (Number(proposal.chainId) === 1 ? 'USDS' : 'sDAI'),
         displayTitle0: proposal.metadata?.display_title_0,
         displayTitle1: proposal.metadata?.display_title_1,
         description: proposal.description || 'No description available',

--- a/src/components/futarchyFi/marketPage/ConfirmSwapModal.jsx
+++ b/src/components/futarchyFi/marketPage/ConfirmSwapModal.jsx
@@ -49,7 +49,7 @@ import { useContractConfig } from '../../../hooks/useContractConfig';
 import DebugToast from './DebugToast';
 import { formatBalance, formatPrice, formatPercentage } from '../../../utils/formatters';
 import { Decimal } from 'decimal.js';
-import { formatWith } from '../../../utils/precisionFormatter';
+import { formatTokenAmount, formatWith } from '../../../utils/precisionFormatter';
 import { getEthersSigner, getEthersProvider, isSafeWallet } from '../../../utils/ethersAdapters';
 import { waitForSafeTxReceipt } from '../../../utils/waitForSafeTxReceipt';
 import { useSubgraphRefresh } from '../../../contexts/SubgraphRefreshContext';
@@ -3908,7 +3908,7 @@ const ConfirmSwapModal = memo(({
                                                     <>
                                                         {(() => {
                                                             const amountFormatted = ethers.utils.formatUnits(swapRouteData.data.buyAmount, 18);
-                                                            return formatWith(parseFloat(amountFormatted), 'amount');
+                                                            return formatTokenAmount(amountFormatted);
                                                         })()} {transactionData.receiveToken ||
                                                             (transactionData.action === 'Buy'
                                                                 ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
@@ -3940,7 +3940,7 @@ const ConfirmSwapModal = memo(({
                                                         {(() => {
                                                             const amountFormatted = ethers.utils.formatUnits(swapRouteData.data.buyAmount, 18);
                                                             const minReceive = parseFloat(amountFormatted) * (1 - getSafeSlippageTolerance() / 100);
-                                                            return formatWith(minReceive, 'amount');
+                                                            return formatTokenAmount(minReceive);
                                                         })()} {transactionData.receiveToken ||
                                                             (transactionData.action === 'Buy'
                                                                 ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
@@ -4094,7 +4094,7 @@ const ConfirmSwapModal = memo(({
                                                     <>
                                                         {(() => {
                                                             const amountFormatted = ethers.utils.formatUnits(swapRouteData.data.buyAmount, 18);
-                                                            return formatWith(parseFloat(amountFormatted), 'amount');
+                                                            return formatTokenAmount(amountFormatted);
                                                         })()} {transactionData.receiveToken ||
                                                             (transactionData.action === 'Buy'
                                                                 ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
@@ -4118,7 +4118,7 @@ const ConfirmSwapModal = memo(({
                                                     '-'
                                                 ) : swapRouteData.data?.minimumReceivedFormatted ? (
                                                     <>
-                                                        {formatWith(parseFloat(swapRouteData.data.minimumReceivedFormatted), 'amount')} {transactionData.receiveToken ||
+                                                        {formatTokenAmount(swapRouteData.data.minimumReceivedFormatted)} {transactionData.receiveToken ||
                                                             (transactionData.action === 'Buy'
                                                                 ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
                                                                 : (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).currency.symbol)}
@@ -4231,7 +4231,7 @@ const ConfirmSwapModal = memo(({
                                         <div className="flex justify-between">
                                             <span className="text-futarchyGray11 dark:text-futarchyGray112/80">Expected Receive</span>
                                             <span className="text-futarchyGray12 dark:text-futarchyGray3 font-medium">
-                                                {formatWith(parseFloat(transactionData.expectedReceiveAmount), 'amount')} {transactionData.receiveToken ||
+                                                {formatTokenAmount(transactionData.expectedReceiveAmount)} {transactionData.receiveToken ||
                                                     (transactionData.action === 'Buy'
                                                         ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
                                                         : (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).currency.symbol)}
@@ -4245,7 +4245,7 @@ const ConfirmSwapModal = memo(({
                                                 )}
                                             </span>
                                             <span className="text-futarchyGray12 dark:text-futarchyGray3 font-medium">
-                                                {formatWith(parseFloat(transactionData.expectedReceiveAmount) * (1 - getSafeSlippageTolerance() / 100), 'amount')} {transactionData.receiveToken ||
+                                                {formatTokenAmount(parseFloat(transactionData.expectedReceiveAmount) * (1 - getSafeSlippageTolerance() / 100))} {transactionData.receiveToken ||
                                                     (transactionData.action === 'Buy'
                                                         ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
                                                         : (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).currency.symbol)}
@@ -4626,7 +4626,7 @@ const ConfirmSwapModal = memo(({
                                     <div className="flex justify-between text-sm">
                                         <span className="text-futarchyGreen11/70 dark:text-futarchyGreenDark11/70">You received</span>
                                         <span className="text-futarchyGreen11 dark:text-futarchyGreenDark11 font-medium">
-                                            ~{formatWith(parseFloat(transactionData.expectedReceiveAmount), 'amount')} {transactionData.receiveToken ||
+                                            ~{formatTokenAmount(transactionData.expectedReceiveAmount)} {transactionData.receiveToken ||
                                                 (transactionData.action === 'Buy'
                                                     ? (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).company.symbol
                                                     : (BASE_TOKENS_CONFIG || DEFAULT_BASE_TOKENS_CONFIG).currency.symbol)}

--- a/src/components/futarchyFi/marketPage/MarketBalancePanel.jsx
+++ b/src/components/futarchyFi/marketPage/MarketBalancePanel.jsx
@@ -226,7 +226,8 @@ const MarketBalancePanel = ({
   const { config } = useContractConfig(proposalId);
 
   // Helper functions for dynamic token symbols with fallbacks
-  const getCurrencySymbol = () => config?.BASE_TOKENS_CONFIG?.currency?.symbol || 'SDAI';
+  const getCurrencySymbol = () => config?.BASE_TOKENS_CONFIG?.currency?.symbol ||
+    (Number(config?.chainId) === 1 ? 'USDS' : 'sDAI');
   const getCompanySymbol = () => config?.BASE_TOKENS_CONFIG?.company?.symbol || 'COMPANY';
 
   // Get token URLs for "BUY" links - use chain ID from config (1 for mainnet, 100 for Gnosis)

--- a/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
+++ b/src/components/futarchyFi/marketPage/MarketPageShowcase.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, memo, useState, useCallback, useMemo } from "
 import { useSearchParams } from 'next/navigation';
 import Image from "next/image";
 import RootLayout from "../../../components/layout/RootLayout";
-import { ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS } from '../../../config/featureFlags';
+import { ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS, SHOW_DATA_DEBUG } from '../../../config/featureFlags';
 import { StatDisplay, AggregatedStatDisplay, formatVolume, formatLiquidity, normalizeTokenAmount } from './page/Formatter';
 import ImpactIcon from './page/icons/ImpactIcon';
 import LiquidityIcon from './page/icons/LiquidityIcon';
@@ -1412,9 +1412,9 @@ const TradeHistoryTable = React.memo(({ tokenImages = { company: null, currency:
         ) : (isLoading || (loadingFromHook && trades.length === 0 && !forceShowData)) ? (
           <div className="py-8 text-center text-futarchyGray11">
             {retryCount > 0 ? `Retrying... (${retryCount}/${MAX_RETRIES})` : 'Loading trades...'}
-            <div className="text-xs mt-1 text-futarchyGray8">
+            {SHOW_DATA_DEBUG && <div className="text-xs mt-1 text-futarchyGray8">
               Local: {isLoading ? 'loading' : 'ready'} | Hook: {loadingFromHook ? 'loading' : 'ready'} | Trades: {trades.length} | Force: {forceShowData ? 'yes' : 'no'}
-            </div>
+            </div>}
           </div>
         ) : error ? (
           <div className="py-8 text-center text-futarchyCrimson11">
@@ -1528,6 +1528,43 @@ const PriceHeader = ({ yesPrice, noPrice, currencySymbol }) => (
           <span className="text-futarchyGold8">NO: {noPrice === null || noPrice === undefined ? 'N/A' : `${noPrice.toFixed(4)} ${currencySymbol}`}</span>
         </div>
       </div>
+    </div>
+  </div>
+);
+
+const YourViewCard = ({ subject }) => (
+  <div className="bg-futarchyGray3 dark:bg-futarchyDarkGray3 rounded-3xl border-2 border-futarchyGray62 dark:border-futarchyGray11/70 overflow-hidden">
+    <div className="px-4 py-3 bg-futarchyGray2 dark:bg-futarchyDarkGray2 border-b-2 border-futarchyGray62 dark:border-futarchyGray11/70">
+      <h3 className="font-oxanium text-sm font-semibold text-futarchyGray12 dark:text-white">
+        Your view on {subject}
+      </h3>
+    </div>
+    <div className="px-4 py-3">
+      <table className="w-full table-fixed font-oxanium text-xs text-center">
+        <thead>
+          <tr className="text-futarchyGray11 dark:text-white/60">
+            <th className="pb-2 text-left font-medium" />
+            <th className="pb-2 font-medium">If YES</th>
+            <th className="pb-2 font-medium">If NO</th>
+          </tr>
+        </thead>
+        <tbody className="text-futarchyGray12 dark:text-white">
+          <tr className="border-t border-futarchyGray62 dark:border-futarchyGray11/50">
+            <th scope="row" className="py-2 text-left font-medium">
+              <span className="inline-block w-2 h-2 mr-2 rounded-full bg-futarchyTeal9" />Bullish
+            </th>
+            <td className="py-2 font-semibold text-futarchyTeal9">BUY</td>
+            <td className="py-2 font-semibold text-futarchyCrimson9">SELL</td>
+          </tr>
+          <tr className="border-t border-futarchyGray62 dark:border-futarchyGray11/50">
+            <th scope="row" className="py-2 text-left font-medium">
+              <span className="inline-block w-2 h-2 mr-2 rounded-full bg-futarchyCrimson9" />Bearish
+            </th>
+            <td className="py-2 font-semibold text-futarchyCrimson9">SELL</td>
+            <td className="py-2 font-semibold text-futarchyTeal9">BUY</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 );
@@ -1980,7 +2017,7 @@ const SnapshotWidget = ({
 
           <span className="text-xs md:text-sm whitespace-nowrap flex-shrink-0">
             Final Result
-            {snapshotSource === 'api' && (
+            {SHOW_DATA_DEBUG && snapshotSource === 'api' && (
               <span className="ml-1 text-[10px] text-futarchyViolet9 dark:text-futarchyViolet7">●</span>
             )}
           </span>
@@ -2036,7 +2073,7 @@ const SnapshotWidget = ({
             <>
               <span className="text-xs md:text-sm whitespace-nowrap flex-shrink-0">
                 Snapshot Results
-                {snapshotSource === 'api' && (
+                {SHOW_DATA_DEBUG && snapshotSource === 'api' && (
                   <span className="ml-1 text-[10px] text-futarchyViolet9 dark:text-futarchyViolet7">●</span>
                 )}
               </span>
@@ -2363,7 +2400,9 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
   const chainValidation = useChainValidation(config, configLoading);
 
   // Get currency symbol from config (used for display throughout component)
-  const currencySymbol = config?.BASE_TOKENS_CONFIG?.currency?.symbol || 'sDAI';
+  const currencySymbol = config?.BASE_TOKENS_CONFIG?.currency?.symbol ||
+    config?.metadata?.currencyTokens?.base?.tokenSymbol ||
+    (Number(config?.chainId || proposal?.chainId) === 1 ? 'USDS' : 'sDAI');
   const companySymbol = config?.BASE_TOKENS_CONFIG?.company?.symbol || DEFAULT_BASE_TOKENS_CONFIG?.company?.symbol || 'GNO';
 
   // Check if connected user is the proposal owner (for edit permissions)
@@ -2431,8 +2470,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
       }
 
       const entries = [
-        { token: liquidity.token0, amount: liquidity.amount0 },
-        { token: liquidity.token1, amount: liquidity.amount1 }
+        { token: liquidity.token0, amount: liquidity.amount0, kind: liquidity.kind0 },
+        { token: liquidity.token1, amount: liquidity.amount1, kind: liquidity.kind1 }
       ];
 
       let cashValue = 0;
@@ -2444,9 +2483,9 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
         const normalizedAmount = normalizeTokenAmount(entry.amount);
         const tokenAddress = entry.token?.toLowerCase();
 
-        if (currencyAddress && tokenAddress === currencyAddress) {
+        if (entry.kind === 'currency' || (currencyAddress && tokenAddress === currencyAddress)) {
           cashValue += normalizedAmount;
-        } else if (companyAddress && tokenAddress === companyAddress) {
+        } else if (entry.kind === 'company' || (companyAddress && tokenAddress === companyAddress)) {
           companyTokenAmount += normalizedAmount;
         } else {
           otherValue += normalizedAmount;
@@ -2467,8 +2506,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
       };
     };
 
-    const yesPrice = parsePrice(newYesPrice ?? latestPrices.yes);
-    const noPrice = parsePrice(newNoPrice ?? latestPrices.no);
+    const yesPrice = parsePrice(newYesPrice ?? poolData?.yesPool?.price ?? latestPrices.yes);
+    const noPrice = parsePrice(newNoPrice ?? poolData?.noPool?.price ?? latestPrices.no);
 
     const yesData = computeBreakdown(poolData?.yesPool?.liquidity, yesPrice);
     const noData = computeBreakdown(poolData?.noPool?.liquidity, noPrice);
@@ -2551,6 +2590,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     config?.BASE_TOKENS_CONFIG,
     poolData?.yesPool?.liquidity,
     poolData?.noPool?.liquidity,
+    poolData?.yesPool?.price,
+    poolData?.noPool?.price,
     newYesPrice,
     newNoPrice,
     latestPrices.yes,
@@ -2885,6 +2926,31 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
     isLoading: true,
     error: null
   });
+
+  const marketSubject = useMemo(() => {
+    const displayTexts = [
+      marketData.display_title_1,
+      marketData.display_title_0,
+      marketData.title,
+      config?.marketInfo?.display_text_1,
+      config?.marketInfo?.title
+    ].filter(Boolean);
+    const identifier = displayTexts.join(' ').match(/\b(?:EIP|GIP|KIP|ERC|RIP|SIP|AIP|MIP|TIP)[-\s]?\d+\b/i)?.[0];
+
+    if (identifier) return identifier.replace(/\s+/, '-').toUpperCase();
+
+    const fallback = String(displayTexts[0] || 'this market')
+      .replace(/^\s*if\s+/i, '')
+      .replace(/[?.!]+$/, '')
+      .trim();
+    return fallback.length > 48 ? `${fallback.slice(0, 45).trimEnd()}…` : fallback;
+  }, [
+    marketData.display_title_1,
+    marketData.display_title_0,
+    marketData.title,
+    config?.marketInfo?.display_text_1,
+    config?.marketInfo?.title
+  ]);
 
   const [selectedToken, setSelectedToken] = useState('currency');
 
@@ -4812,7 +4878,7 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
               />
 
               <AggregatedStatDisplay
-                label={poolData?.source === 'subgraph' ? 'Liquidity' : `Liquidity (Total; ${currencySymbol})`}
+                label="Liquidity"
                 yesValue={liquiditySummary.yes?.total ?? null}
                 noValue={liquiditySummary.no?.total ?? null}
                 Icon={LiquidityIcon}
@@ -5351,6 +5417,8 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
                           </div>
                         )}
 
+                        <YourViewCard subject={marketSubject} />
+
                         {/* Balance Stats Container */}
                         <MarketBalancePanel
                           positions={positions}
@@ -5646,7 +5714,7 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
           />
 
           {/* Snapshot Debug Console - Shows when debug mode is active */}
-          {isDebugMode && (
+          {SHOW_DATA_DEBUG && isDebugMode && (
             <div className="fixed top-4 right-4 z-50 bg-black/90 text-white p-4 rounded-lg max-w-md text-xs font-mono">
               <div className="font-bold mb-2 text-futarchyViolet9">📊 Snapshot Widget Debug</div>
               <div className="space-y-1">
@@ -5667,7 +5735,7 @@ const MarketPageShowcase = ({ hidden = false, debugMode = false, proposal = null
           )}
 
           {/* Market Analytics Toast - Hidden on Mobile and when debug mode is false */}
-          {isDebugMode && (
+          {SHOW_DATA_DEBUG && isDebugMode && (
             <div className="hidden md:block">
               <MarketStatsDebugToast
                 prices={prices}

--- a/src/components/futarchyFi/marketPage/PoolDataDisplay.jsx
+++ b/src/components/futarchyFi/marketPage/PoolDataDisplay.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useYesNoPoolData } from '../../../hooks/usePoolData';
 import { ethers } from 'ethers';
+import { SHOW_DATA_DEBUG } from '../../../config/featureFlags';
 
 const PoolDataDisplay = ({ config }) => {
   const { data, loading, error } = useYesNoPoolData(config);
@@ -136,7 +137,7 @@ const PoolDataDisplay = ({ config }) => {
       </div>
 
       {/* Source Indicator Badge - Always Show if source is determined */}
-      {data.source && data.source !== 'loading' && (
+      {SHOW_DATA_DEBUG && data.source && data.source !== 'loading' && (
         <div className="flex justify-end w-full mt-2">
           <div
             className={`text-[10px] uppercase font-bold tracking-wider ${sourceColor} border border-white/10 px-2 py-0.5 rounded cursor-help`}

--- a/src/components/futarchyFi/marketPage/ShowcaseSwapComponent.jsx
+++ b/src/components/futarchyFi/marketPage/ShowcaseSwapComponent.jsx
@@ -34,7 +34,7 @@ import { fetchSushiSwapRoute, executeSushiSwapRoute } from '../../../utils/sushi
 import { formatBalance, formatPercentage } from '../../../utils/formatters';
 import { useCurrency } from '../../../contexts/CurrencyContext';
 import { useContractConfig } from '../../../hooks/useContractConfig';
-import { formatWith } from '../../../utils/precisionFormatter';
+import { formatTokenAmount, formatWith } from '../../../utils/precisionFormatter';
 import { getUniswapV3QuoteWithPriceImpact, getPoolSqrtPrice, sqrtPriceX96ToPrice } from '../../../utils/uniswapSdk';
 import { usePublicClient, useChainId } from 'wagmi';
 import { approvalAmountFor } from '../../../utils/approvalAmount';
@@ -1533,7 +1533,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
 
                         if ((chainId === 1 || chainId === 100) && quoterPreview.amountOut) {
                           const symbol = selectedAction === 'Buy' ? getCompanySymbol() : getCurrencySymbol();
-                          return `${formatWith(parseFloat(quoterPreview.amountOut), 'swapPrice')} ${symbol}`;
+                          return `${formatTokenAmount(quoterPreview.amountOut)} ${symbol}`;
                         }
 
                         // Fallback to price calculation
@@ -1545,7 +1545,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
                           ? inputAmount / noPrice
                           : inputAmount * noPrice;
                         const symbol = selectedAction === 'Buy' ? getCompanySymbol() : getCurrencySymbol();
-                        return `${formatWith(value, 'swapPrice')} ${symbol} (estimate)`;
+                        return `${formatTokenAmount(value)} ${symbol} (estimate)`;
                       })()}
                     </span>
                     <span className="text-xs text-futarchyGray11 dark:text-futarchyGray112">
@@ -1597,7 +1597,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
                       {(() => {
                         const value = parseFloat(amount) || 0;
                         const symbol = selectedAction === 'Buy' ? getCurrencySymbol() : getCompanySymbol();
-                        return `${formatWith(value, 'swapPrice')} ${symbol} (estimate)`;
+                        return `${formatTokenAmount(value)} ${symbol} (estimate)`;
                       })()}
                     </span>
                     <span className="text-xs text-futarchyGray11 dark:text-futarchyGray112">Recover</span>
@@ -1632,7 +1632,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
 
                         if ((chainId === 1 || chainId === 100) && quoterPreview.amountOut) {
                           const symbol = selectedAction === 'Buy' ? getCompanySymbol() : getCurrencySymbol();
-                          return `${formatWith(parseFloat(quoterPreview.amountOut), 'swapPrice')} ${symbol}`;
+                          return `${formatTokenAmount(quoterPreview.amountOut)} ${symbol}`;
                         }
 
                         // Fallback to price calculation
@@ -1644,7 +1644,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
                           ? inputAmount / yesPrice
                           : inputAmount * yesPrice;
                         const symbol = selectedAction === 'Buy' ? getCompanySymbol() : getCurrencySymbol();
-                        return `${formatWith(value, 'swapPrice')} ${symbol}`;
+                        return `${formatTokenAmount(value)} ${symbol}`;
                       })()}
                     </span>
                     <span className="text-xs text-futarchyGray11 dark:text-futarchyGray112">
@@ -1696,7 +1696,7 @@ const ShowcaseSwapComponent = ({ positions, prices, walletBalances, isLoadingBal
                       {(() => {
                         const value = parseFloat(amount) || 0;
                         const symbol = selectedAction === 'Buy' ? getCurrencySymbol() : getCompanySymbol();
-                        return `${formatWith(value, 'swapPrice')} ${symbol}`;
+                        return `${formatTokenAmount(value)} ${symbol}`;
                       })()}
                     </span>
                     <span className="text-xs text-futarchyGray11 dark:text-futarchyGray112">Recover</span>

--- a/src/components/futarchyFi/marketPage/SubgraphTradesDataLayer.jsx
+++ b/src/components/futarchyFi/marketPage/SubgraphTradesDataLayer.jsx
@@ -17,6 +17,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useAccount } from 'wagmi';
 import { fetchFormattedTrades, fetchPoolsForProposal } from '../../../utils/subgraphTradesClient';
 import { useSubgraphRefresh } from '../../../contexts/SubgraphRefreshContext';
+import { SHOW_DATA_DEBUG } from '../../../config/featureFlags';
 
 const REFRESH_INTERVAL = 45000; // 45 seconds
 
@@ -205,7 +206,7 @@ const SubgraphTradesDataLayer = ({
             <div className="flex items-center justify-center py-12">
                 <div className="text-center">
                     <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-futarchyViolet9 mb-4"></div>
-                    <p className="text-futarchyGray11 dark:text-futarchyGray112">Loading from Subgraph...</p>
+                    <p className="text-futarchyGray11 dark:text-futarchyGray112">{SHOW_DATA_DEBUG ? 'Loading from Subgraph...' : 'Loading trades...'}</p>
                 </div>
             </div>
         );
@@ -234,7 +235,7 @@ const SubgraphTradesDataLayer = ({
         return (
             <div className="relative">
                 {/* Subgraph Status Bar */}
-                <div className="flex items-center justify-between px-4 py-2 mb-2 bg-futarchyGray3 dark:bg-futarchyDarkGray3 rounded-lg border border-futarchyGray62 dark:border-futarchyDarkGray42">
+                {SHOW_DATA_DEBUG && <div className="flex items-center justify-between px-4 py-2 mb-2 bg-futarchyGray3 dark:bg-futarchyDarkGray3 rounded-lg border border-futarchyGray62 dark:border-futarchyDarkGray42">
                     <div className="flex items-center gap-3">
                         <span className="px-2 py-0.5 text-xs font-medium bg-futarchyTeal4 text-futarchyTeal11 dark:bg-futarchyTeal4/20 dark:text-futarchyTeal7 rounded-full border border-futarchyTeal6 dark:border-futarchyTeal7">
                             Subgraph
@@ -258,7 +259,7 @@ const SubgraphTradesDataLayer = ({
                             Resync
                         </button>
                     </div>
-                </div>
+                </div>}
                 <div className="flex items-center justify-center py-12 text-futarchyGray11 dark:text-futarchyGray112">
                     {showMyTrades && !isConnected
                         ? 'Connect wallet to view your trades'
@@ -274,7 +275,7 @@ const SubgraphTradesDataLayer = ({
     return (
         <div className="relative">
             {/* Subgraph Status Bar */}
-            <div className="flex items-center justify-between px-4 py-2 mb-2 bg-futarchyGray3 dark:bg-futarchyDarkGray3 rounded-lg border border-futarchyGray62 dark:border-futarchyDarkGray42">
+            {SHOW_DATA_DEBUG && <div className="flex items-center justify-between px-4 py-2 mb-2 bg-futarchyGray3 dark:bg-futarchyDarkGray3 rounded-lg border border-futarchyGray62 dark:border-futarchyDarkGray42">
                 <div className="flex items-center gap-3">
                     <span className="px-2 py-0.5 text-xs font-medium bg-futarchyTeal4 text-futarchyTeal11 dark:bg-futarchyTeal4/20 dark:text-futarchyTeal7 rounded-full border border-futarchyTeal6 dark:border-futarchyTeal7">
                         Subgraph
@@ -298,7 +299,7 @@ const SubgraphTradesDataLayer = ({
                         Resync
                     </button>
                 </div>
-            </div>
+            </div>}
 
             {/* Desktop Table View */}
             <div className="hidden md:block rounded-2xl border border-futarchyGray62 dark:border-futarchyDarkGray42 bg-futarchyGray2 dark:bg-futarchyDarkGray3">
@@ -308,7 +309,7 @@ const SubgraphTradesDataLayer = ({
                             <thead>
                                 <tr className="border-b-2 border-futarchyGray62 dark:border-futarchyDarkGray42 dark:bg-futarchyDarkGray3 h-[60px]">
                                     <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-left px-4 w-[180px]">Outcome</th>
-                                    <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-left px-4 w-[100px]">Type</th>
+                                    {SHOW_DATA_DEBUG && <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-left px-4 w-[100px]">Type</th>}
                                     <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-left px-4 w-[180px]">Amount</th>
                                     <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-right px-4 w-[100px]">Price</th>
                                     <th className="text-xs text-futarchyGray11 dark:text-futarchyGray112 font-semibold text-right px-4 w-[140px]">Date</th>
@@ -351,7 +352,7 @@ const SubgraphTradesDataLayer = ({
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td className="px-4 w-[100px]">
+                                                {SHOW_DATA_DEBUG && <td className="px-4 w-[100px]">
                                                     <span className={`px-2 py-0.5 text-[10px] font-medium rounded-full ${trade.poolType === 'PREDICTION'
                                                         ? 'bg-futarchyViolet4 text-futarchyViolet11 border border-futarchyViolet6 dark:bg-transparent dark:text-futarchyViolet7 dark:border-futarchyViolet7'
                                                         : trade.poolType === 'CONDITIONAL'
@@ -360,7 +361,7 @@ const SubgraphTradesDataLayer = ({
                                                         }`}>
                                                         {trade.poolType || 'UNKNOWN'}
                                                     </span>
-                                                </td>
+                                                </td>}
                                                 <td className="px-4 w-[180px]">
                                                     <div className="flex flex-col gap-1">
                                                         <span className="text-xs font-semibold text-futarchyGray12 dark:text-futarchyGray112 whitespace-nowrap flex items-center">

--- a/src/components/futarchyFi/marketPage/page/Formatter.jsx
+++ b/src/components/futarchyFi/marketPage/page/Formatter.jsx
@@ -207,11 +207,15 @@ export const AggregatedStatDisplay = ({
     normalize = true
 }) => {
     const formatValue = formatFunction || formatNumber;
+    // Distinguish "no data" (RPC/indexer failure -> null on both sides) from a
+    // genuine zero: a $0 reading on a live market is misleading, show a dash.
+    const noData = (yesValue === null || yesValue === undefined)
+        && (noValue === null || noValue === undefined);
     const normalizedYes = normalize ? normalizeTokenAmount(yesValue) : (Number(yesValue) || 0);
     const normalizedNo = normalize ? normalizeTokenAmount(noValue) : (Number(noValue) || 0);
     const total = normalizedYes + normalizedNo;
 
-    const formattedTotal = formatValue(total);
+    const formattedTotal = noData ? '—' : formatValue(total);
     const breakdownItems = (tooltipBreakdown && tooltipBreakdown.length > 0
         ? tooltipBreakdown
         : [

--- a/src/components/futarchyFi/proposalsList/cards/ProposalsCard.jsx
+++ b/src/components/futarchyFi/proposalsList/cards/ProposalsCard.jsx
@@ -293,14 +293,14 @@ const ProposalStatus = ({ approvalStatus }) => {
 };
 
 // Update the ProposalsPrices component to handle numerical prices and loading state
-const ProposalsPrices = ({ approvalPrice, refusalPrice, approvalStatus, isLoading, metadata }) => {
+const ProposalsPrices = ({ approvalPrice, refusalPrice, approvalStatus, isLoading, metadata, chainId }) => {
   const currentColors = statusColors[approvalStatus] || statusColors.ongoing;
   const [dividerColor, setDividerColor] = useState("bg-futarchyGray4 dark:bg-futarchyGray112/20");
 
   // Extract base token symbol from metadata
   const baseTokenSymbol = metadata?.currencyTokens?.base?.tokenSymbol ||
     metadata?.BASE_TOKENS_CONFIG?.currency?.symbol ||
-    'SDAI';
+    (Number(metadata?.chain || chainId) === 1 ? 'USDS' : 'sDAI');
 
   // Use high precision for inverted prices or small prices
   const shouldUseHighPrecision = metadata?.invertCondPoolPrice === true ||
@@ -380,6 +380,7 @@ export const ProposalsCard = ({
   predictionPools,
   poolAddresses,
   metadata,
+  chainId,
   resolutionStatus,
   visibility = 'public',
   isOwner = false,
@@ -541,6 +542,7 @@ export const ProposalsCard = ({
                   approvalStatus={approvalStatus}
                   isLoading={isLoadingPrices}
                   metadata={metadata}
+                  chainId={chainId}
                 />
 
                 {/* Add Impact and Event Probability */}
@@ -602,6 +604,7 @@ export const MobileProposalsCard = ({
   predictionPools,
   poolAddresses,
   metadata,
+  chainId,
   resolutionStatus,
   visibility = 'public',
   isOwner = false,
@@ -757,6 +760,7 @@ export const MobileProposalsCard = ({
                 approvalStatus={approvalStatus}
                 isLoading={isLoadingPrices}
                 metadata={metadata}
+                chainId={chainId}
               />
 
               {/* Impact and Event Probability - Stacked for mobile */}

--- a/src/components/futarchyFi/proposalsList/page/proposalsPage/ProposalsPage.jsx
+++ b/src/components/futarchyFi/proposalsList/page/proposalsPage/ProposalsPage.jsx
@@ -17,6 +17,7 @@ import PageLayout from "../../../../layout/PageLayout";
 import { useOrganization } from "../../../../../hooks/useOrganization";
 import { useChainId } from "wagmi";
 import OrganizationManagerModal from "../../../../debug/OrganizationManagerModal";
+import { SHOW_DATA_DEBUG } from "../../../../../config/featureFlags";
 
 const PROPOSAL_IMAGES = {
   "ethereum-budget": "/assets/ethereum-budget-picture.webp",
@@ -198,6 +199,7 @@ const ProposalsPage = ({
               prices: { yes: yesPrice, no: noPrice },
               impact,
               metadata: {
+                ...proposalMeta,
                 background_image: subgraphOrg.coverImage || subgraphOrg.logo,
                 display_title_0: p.displayNameQuestion,
                 display_title_1: p.displayNameEvent
@@ -329,7 +331,7 @@ const ProposalsPage = ({
                 {companyData.currencyToken}
               </div>
               {/* Subgraph badge */}
-              {companyData.fromSubgraph && (
+              {SHOW_DATA_DEBUG && companyData.fromSubgraph && (
                 <div className="py-1 px-2 bg-purple-600 rounded-full text-white text-sm leading-4 font-medium">
                   📊 Subgraph
                 </div>

--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -1,11 +1,10 @@
 /**
- * Feature Flags — all permanently enabled
+ * Feature Flags
  *
- * These flags were used during the V1→V2 migration and are now always true.
- * Kept as named exports to avoid touching 15+ import sites.
- * Safe to inline and remove in a future cleanup pass.
+ * The migration flags remain enabled. Data-source diagnostics are opt-in.
  */
 
 export const ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS = true;
 export const ENABLE_V2_SUBGRAPH = true;
 export const USE_QUERY_PARAM_URLS = true;
+export const SHOW_DATA_DEBUG = process.env.NEXT_PUBLIC_SHOW_DATA_DEBUG === 'true';

--- a/src/hooks/useAggregatorProposals.js
+++ b/src/hooks/useAggregatorProposals.js
@@ -136,6 +136,8 @@ function transformProposalToEvent(proposal, org, connectedWallet) {
 
     const resolved = isProposalResolved(proposalMeta);
     const closed = isProposalClosed(proposalMeta);
+    const currencySymbol = proposalMeta?.currencyTokens?.base?.tokenSymbol ||
+        (detectedChain === 1 ? 'USDS' : 'sDAI');
 
     return {
         // =============================================
@@ -157,8 +159,8 @@ function transformProposalToEvent(proposal, org, connectedWallet) {
 
         // Stats placeholder (will be fetched by card from Market Subgraph)
         stats: {
-            yesPrice: '0.50 SDAI',
-            noPrice: '0.50 SDAI'
+            yesPrice: `0.50 ${currencySymbol}`,
+            noPrice: `0.50 ${currencySymbol}`
         },
 
         // Pool info - will need to fetch from market subgraph or metadata

--- a/src/hooks/usePoolData.js
+++ b/src/hooks/usePoolData.js
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react';
+import { ethers } from 'ethers';
 import { getSubgraphEndpoint } from '../config/subgraphEndpoints';
 import { ENABLE_SUBGRAPH_FOR_ALL_PROPOSALS } from '../config/featureFlags';
+import { getBestRpcProvider } from '../utils/getBestRpc';
+
+const ERC20_BALANCE_ABI = ['function balanceOf(address account) view returns (uint256)'];
 
 // Pool data subgraph endpoints are now dynamic per chain - see getSubgraphEndpoint(chainId)
 
@@ -72,8 +76,8 @@ const buildTokensForPoolQuery = (proposalId) => `{
 }`;
 
 // Helper to format a raw subgraph pool into our app's data structure
-const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
-  if (!pool) return { volume: 0, liquidity: { amount: 0, isRaw: true } };
+const formatSubgraphPoolData = async (pool, proposalCurrencySymbol, provider) => {
+  if (!pool) return { volume: 0, liquidity: null, price: null };
 
   // Intelligent Volume Aggregation using ROLES or Currency Symbol
   let volumeTotal = 0;
@@ -92,7 +96,7 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
   // Fallback: Check symbol if role is missing/ambiguous
   const isCurrencySymbol = (t) => {
     if (!proposalCurrencySymbol) return false;
-    return t.symbol?.toLowerCase() === proposalCurrencySymbol.toLowerCase();
+    return t.symbol?.replace(/^(YES|NO)_/i, '').toLowerCase() === proposalCurrencySymbol.toLowerCase();
   };
 
   // Checkpoint stores volumeToken0/1 as raw token-decimal strings (e.g.
@@ -116,7 +120,9 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
 
   // Fallback if no clear currency
   if (volumeTotal === 0 && !currencyIsToken0 && !currencyIsToken1) {
-    const isCommonStable = (s) => s?.includes('DAI') || s?.includes('USDC');
+    const isCommonStable = (s) => s?.toUpperCase().includes('DAI') ||
+      s?.toUpperCase().includes('USDC') ||
+      s?.toUpperCase().includes('USDS');
     if (isCommonStable(t0.symbol)) { volumeTotal += vol0; currencyIsToken0 = true; }
     else if (isCommonStable(t1.symbol)) { volumeTotal += vol1; currencyIsToken1 = true; }
     else {
@@ -124,43 +130,6 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
       volumeTotal += vol1;
       currencyIsToken1 = true;
     }
-  }
-
-  // Convert Algebra V3 raw L to a currency-denominated TVL approximation.
-  //
-  // For a full-range position at the current price, the underlying token
-  // reserves are roughly amount0 ≈ L / sqrtPrice and amount1 ≈ L × sqrtPrice
-  // (in raw 1e18-scaled units when both tokens have 18 decimals). The total
-  // TVL valued in the currency token is therefore:
-  //
-  //   TVL_currency_wei ≈ amount_currency + amount_company × price
-  //                    = L × sqrtPrice + (L / sqrtPrice) × price
-  //                    = 2 × L × sqrtPrice         (since price = sqrtPrice²)
-  //
-  // We then divide by 1e18 to express it in currency-token units.
-  let adjustedLiquidity = parseFloat(pool.liquidity || 0);
-
-  try {
-    if (pool.tick) {
-      const tick = parseFloat(pool.tick);
-      const sqrtPrice = Math.pow(1.0001, tick / 2);
-      if (sqrtPrice > 0) {
-        const liquidityScaled = currencyIsToken0
-          ? adjustedLiquidity / sqrtPrice
-          : adjustedLiquidity * sqrtPrice;
-        // Both reserves at center → roughly 2× the single-side estimate;
-        // /1e18 to convert from raw token-scaled wei to currency units.
-        adjustedLiquidity = (liquidityScaled * 2) / 1e18;
-      } else {
-        adjustedLiquidity = 0;
-      }
-    } else {
-      // No tick available — fall back to raw-L /1e18 (best effort).
-      adjustedLiquidity = adjustedLiquidity / 1e18;
-    }
-  } catch (e) {
-    console.warn('Error calculating tick-adjusted liquidity:', e);
-    adjustedLiquidity = 0;
   }
 
   // Derive company-token price from tick (price of company token in currency units)
@@ -182,14 +151,35 @@ const formatSubgraphPoolData = (pool, proposalCurrencySymbol) => {
     console.warn('Error calculating price from tick:', e);
   }
 
+  // A V3 pool's ERC20 balances are its real reserves (including uncollected fees).
+  // This works for both Uniswap V3 and Algebra pools without interpreting virtual L.
+  let liquidity = null;
+  try {
+    const normalizeAddress = (address) => address?.replace(/^\d+-/, '');
+    const poolAddress = normalizeAddress(pool.id);
+    const [balance0, balance1] = await Promise.all([
+      new ethers.Contract(normalizeAddress(t0.id), ERC20_BALANCE_ABI, provider).balanceOf(poolAddress),
+      new ethers.Contract(normalizeAddress(t1.id), ERC20_BALANCE_ABI, provider).balanceOf(poolAddress)
+    ]);
+
+    liquidity = {
+      token0: normalizeAddress(t0.id),
+      symbol0: t0.symbol,
+      kind0: currencyIsToken0 ? 'currency' : 'company',
+      amount0: ethers.utils.formatUnits(balance0, Number(t0.decimals ?? 18)),
+      token1: normalizeAddress(t1.id),
+      symbol1: t1.symbol,
+      kind1: currencyIsToken1 ? 'currency' : 'company',
+      amount1: ethers.utils.formatUnits(balance1, Number(t1.decimals ?? 18)),
+      isRaw: false
+    };
+  } catch (e) {
+    console.warn('[Pool Data] Failed to read real pool reserves:', e.message);
+  }
+
   return {
     volume: volumeTotal,
-    liquidity: {
-      // Currency-denominated TVL (already normalized to token units, not wei).
-      amount: adjustedLiquidity.toString(),
-      token: proposalCurrencySymbol || 'sDAI',
-      isRaw: false
-    },
+    liquidity,
     price
   };
 };
@@ -292,13 +282,16 @@ const fetchBestPoolsForProposal = async (proposalId, chainId = 100) => {
       }
     };
 
-    const [yesCandlePrice, noCandlePrice] = await Promise.all([
+    const [yesCandlePrice, noCandlePrice, provider] = await Promise.all([
       yesPool ? fetchLatestCandlePrice(yesPool.id) : Promise.resolve(null),
-      noPool ? fetchLatestCandlePrice(noPool.id) : Promise.resolve(null)
+      noPool ? fetchLatestCandlePrice(noPool.id) : Promise.resolve(null),
+      getBestRpcProvider(chainId)
     ]);
 
-    const yesData = formatSubgraphPoolData(yesPool, currencySymbol);
-    const noData = formatSubgraphPoolData(noPool, currencySymbol);
+    const [yesData, noData] = await Promise.all([
+      formatSubgraphPoolData(yesPool, currencySymbol, provider),
+      formatSubgraphPoolData(noPool, currencySymbol, provider)
+    ]);
 
     // Override tick-derived price with candle price when available
     if (yesCandlePrice != null) {
@@ -380,11 +373,12 @@ const fetchSubgraphPoolData = async (poolId, chainId = 100) => {
       return { id: lc, ...meta };
     };
 
+    const provider = await getBestRpcProvider(chainId);
     return formatSubgraphPoolData({
       ...pool,
       token0: enrichToken(pool.token0),
       token1: enrichToken(pool.token1),
-    });
+    }, null, provider);
 
 
   } catch (error) {

--- a/src/utils/precisionFormatter.js
+++ b/src/utils/precisionFormatter.js
@@ -93,6 +93,28 @@ export function formatWithClean(value, type = 'default', config = null) {
 }
 
 /**
+ * Format user-visible token amounts without scientific notation.
+ * Values below one retain four significant digits, capped at eight decimals.
+ */
+export function formatTokenAmount(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num === 0) return '0.00';
+
+  const absolute = Math.abs(num);
+  let fractionDigits = 2;
+
+  if (absolute < 1) {
+    fractionDigits = Math.min(8, Math.max(4, 3 - Math.floor(Math.log10(absolute))));
+  }
+
+  return num.toLocaleString('en-US', {
+    useGrouping: false,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits
+  });
+}
+
+/**
  * Format a percentage value
  * @param {number|string} value - The decimal value (e.g., 0.5 for 50%)
  * @param {object} config - Optional custom precision config

--- a/src/utils/subgraphTradesClient.js
+++ b/src/utils/subgraphTradesClient.js
@@ -5,7 +5,9 @@
  * Used when ?tradeSource=subgraph URL parameter is set.
  */
 
+import { ethers } from 'ethers';
 import { SUBGRAPH_ENDPOINTS } from '../config/subgraphEndpoints';
+import { formatTokenAmount } from './precisionFormatter';
 
 const ENDPOINTS = SUBGRAPH_ENDPOINTS;
 
@@ -184,34 +186,12 @@ export async function fetchSwapsFromSubgraph(chainId, poolAddresses, userAddress
     }
 }
 
-/**
- * Format a number for display, handling very small/large values
- * Shows significant figures rather than fixed decimals
- */
-function formatAmount(value) {
-    const num = parseFloat(value);
-    if (isNaN(num) || num === 0) return '0';
-
-    const absNum = Math.abs(num);
-
-    // For very small numbers, use scientific notation or significant figures
-    if (absNum < 0.000001) {
-        return num.toExponential(2);
+function formatAmount(value, decimals = 18) {
+    try {
+        return formatTokenAmount(ethers.utils.formatUnits(value || '0', Number(decimals) || 18));
+    } catch (_) {
+        return formatTokenAmount(value);
     }
-    if (absNum < 0.001) {
-        return num.toPrecision(3);
-    }
-    if (absNum < 1) {
-        return num.toFixed(6);
-    }
-    if (absNum < 1000) {
-        return num.toFixed(4);
-    }
-    if (absNum < 1000000) {
-        return num.toFixed(2);
-    }
-    // Large numbers: use compact notation
-    return num.toExponential(2);
 }
 
 /**
@@ -307,12 +287,12 @@ export function convertSwapToTradeFormat(swap, chainId) {
             // tokenOUT = what user GIVES (subgraph's amountIn/tokenIn)
             tokenIN: {
                 symbol: swap.tokenOut?.symbol || 'UNKNOWN',
-                value: formatAmount(swap.amountOut),
+                value: formatAmount(swap.amountOut, swap.tokenOut?.decimals ?? swap.decimalsOut),
                 address: swap.tokenOut?.id
             },
             tokenOUT: {
                 symbol: swap.tokenIn?.symbol || 'UNKNOWN',
-                value: formatAmount(swap.amountIn),
+                value: formatAmount(swap.amountIn, swap.tokenIn?.decimals ?? swap.decimalsIn),
                 address: swap.tokenIn?.id
             }
         },


### PR DESCRIPTION
All six display items from Clément's feedback: debug text behind a default-off flag, ≥2-decimal adaptive precision, human-readable trade amounts, real-reserve liquidity stat (was virtual reserves, ~9× inflated), correct currency symbols, and the bullish/bearish guidance table. Fable adversarial review passed (live-verified liquidity math; refresh timers intact; engine untouched) + its two findings fixed (null→em-dash, decimals-aware amounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)